### PR TITLE
Support *FbtEnum.ts files

### DIFF
--- a/example/src/example/Example$FbtEnum.ts
+++ b/example/src/example/Example$FbtEnum.ts
@@ -4,4 +4,4 @@ export default {
   PHOTO: 'photo',
   POST: 'post',
   VIDEO: 'video',
-};
+} as const;

--- a/example/src/example/Example.react.tsx
+++ b/example/src/example/Example.react.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { fbs, fbt, GenderConst, IntlVariations, setupFbtee } from 'fbtee';
 import { ChangeEvent, useCallback, useState } from 'react';
 import translations from '../translatedFbts.json' with { type: 'json' };
-import ExampleEnum from './Example$FbtEnum.js';
+import ExampleEnum from './Example$FbtEnum.ts';
 
 let viewerContext = {
   GENDER: IntlVariations.GENDER_UNKNOWN,

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,9 @@ import CommonStrings from './example/common_strings.json' with { type: 'json' };
 process.env.NODE_ENV = 'development';
 
 const globalConfig = {
-  extensionsToTreatAsEsm: ['.tsx'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*-test.(js|jsx|tsx)'],
+  testMatch: ['**/__tests__/**/*-test.(js|jsx|ts|tsx)'],
   transform: {
     '\\.(j|t)sx?$': '<rootDir>/jest-preprocessor.js',
   },

--- a/packages/babel-fbtee/src/bin.tsx
+++ b/packages/babel-fbtee/src/bin.tsx
@@ -1,3 +1,3 @@
-#! /usr/bin/env node
+#! /usr/bin/env node --experimental-strip-types --no-warnings
 
 import('@nkzw/babel-plugin-fbtee/lib/bin.js');

--- a/packages/babel-plugin-fbtee/src/bin.tsx
+++ b/packages/babel-plugin-fbtee/src/bin.tsx
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#! /usr/bin/env node --experimental-strip-types --no-warnings
 const command = process.argv[2];
 process.argv.splice(2, 1);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     "target": "es2022"
   },
   "exclude": ["packages/*/lib/", "node_modules"],
-  "include": ["**/*.ts", "**/*.tsx", "example/src/example/Example$FbtEnum.js"]
+  "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
Stacked on #2 (needed the automatic external detection)

Currently you cannot have `.ts` files as enums and you get this error
```
node:internal/modules/esm/get_format:218
  throw new ERR_UNKNOWN_FILE_EXTENSION(ext, filepath);
        ^

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/alex/dev/fbt/example/src/example/Example$FbtEnum.ts
```

I'm not sure the approach I've taken here is optimal, we could potentially use `ts-node` or `esbuild-register` but didn't have much luck with using them in an ESM environment. 

Now every enum file is transpiled using TS regardless of the extension, it might be wiser to only transpile `.tsx?` files. I can update to do that if you think it's a good idea