### PR TITLE
Add no-unhelpful-desc rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,12 @@ module.exports = {
         ),
       },
     ],
+    'import/no-unresolved': [
+      2,
+      {
+        ignore: ['@typescript-eslint/*'],
+      },
+    ],
     'no-extra-parens': 0,
     'unicorn/prefer-dom-node-append': 0,
     'workspaces/no-absolute-imports': 2,

--- a/example/.eslintrc.cjs
+++ b/example/.eslintrc.cjs
@@ -2,5 +2,6 @@ module.exports = {
   plugins: ['fbtee'],
   rules: {
     'fbtee/no-empty-strings': 'error',
+    'fbtee/no-unhelpful-desc': 'error',
   },
 };

--- a/example/.eslintrc.cjs
+++ b/example/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
-  plugins: ['fbtee'],
+  plugins: ['@nkzw/eslint-plugin-fbtee'],
   rules: {
-    'fbtee/no-empty-strings': 'error',
-    'fbtee/no-unhelpful-desc': 'error',
+    '@nkzw/fbtee/no-empty-strings': 'error',
+    '@nkzw/fbtee/no-unhelpful-desc': 'error',
   },
 };

--- a/example/package.json
+++ b/example/package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.26.3",
+    "@nkzw/eslint-plugin-fbtee": "workspace:^",
     "@vitejs/plugin-react": "^4.3.4",
-    "eslint-plugin-fbtee": "workspace:^",
     "invariant": "^2.2.4",
     "vite": "^6.0.3"
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ export default {
   prettierPath: null,
   projects: [
     {
-      displayName: 'babel-plugin-fbt',
+      displayName: '@nkzw/babel-plugin-fbtee',
       roots: ['<rootDir>/packages/babel-plugin-fbtee/src'],
       transform: {
         '\\.(j|t)sx?$': [
@@ -33,11 +33,11 @@ export default {
       },
     },
     {
-      displayName: 'babel-plugin-fbt-runtime',
+      displayName: '@nkzw/babel-plugin-fbtee-runtime',
       roots: ['<rootDir>/packages/babel-plugin-fbtee-runtime'],
     },
     {
-      displayName: 'fbt',
+      displayName: 'fbtee',
       modulePaths: ['<rootDir>/packages/fbtee/src'],
       roots: ['<rootDir>/packages/fbtee/src'],
       testEnvironment: 'jsdom',
@@ -79,7 +79,7 @@ export default {
       },
     },
     {
-      displayName: 'eslint-plugin-fbtee',
+      displayName: '@nkzw/eslint-plugin-fbtee',
       modulePaths: ['<rootDir>/packages/eslint-plugin-fbtee'],
       roots: ['<rootDir>/packages/eslint-plugin-fbtee/src'],
       transform: {

--- a/packages/eslint-plugin-fbtee/docs/rules/no-unhelpful-desc.md
+++ b/packages/eslint-plugin-fbtee/docs/rules/no-unhelpful-desc.md
@@ -1,0 +1,41 @@
+# Prevent unhelpful descriptions being given to `<fbt>` or `fbt()` (fbtee/no-unhelpful-desc)
+
+## Rule Details
+
+This rule enforces that meaningful and non-empty descriptions are provided to <fbt> elements and fbt()/fbs() function calls. Descriptions (desc) are crucial for ensuring proper translation context and avoiding ambiguous or unhelpful translations.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<fbt desc="">Hello world</fbt>
+```
+
+```jsx
+<fbt desc="foo">Hello world</fbt>
+```
+
+```jsx
+<fbt desc="Hello world">Hello world</fbt>
+```
+
+```jsx
+fbt('Hello world', '');
+```
+
+```jsx
+fbt('Hello world', 'foo');
+```
+
+```jsx
+fbt('Hello world', 'hello world');
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<fbt desc="Greeting">Hello</fbt>
+```
+
+```jsx
+fbt('Hello', 'Greeting');
+```

--- a/packages/eslint-plugin-fbtee/package.json
+++ b/packages/eslint-plugin-fbtee/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-fbtee",
+  "name": "@nkzw/eslint-plugin-fbtee",
   "version": "0.0.1",
   "description": "",
   "keywords": [],

--- a/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
-
-// eslint-disable-next-line import/no-unresolved
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import rule from '../rules/no-empty-strings.tsx';
 
@@ -15,6 +12,146 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-empty-strings', rule, {
+  invalid: [
+    {
+      code: `
+        <fbt desc="Greeting"></fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">{''}</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">{\`\`}</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">  </fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          {' '}
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          <span></span>
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          <></>
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('', 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt(' ', 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt(\`\`, 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt(\` \`, 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        fbs('', 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyString',
+        },
+      ],
+    },
+  ],
   valid: [
     {
       code: `
@@ -68,146 +205,6 @@ ruleTester.run('no-empty-strings', rule, {
           <>Hello</>
         </fbt>;
       `,
-    },
-  ],
-  invalid: [
-    {
-      code: `
-        <fbt desc="Greeting"></fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">{''}</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">{\`\`}</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">  </fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">
-          {' '}
-        </fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 3,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">
-          <span></span>
-        </fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 3,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">
-          <></>
-        </fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyString',
-          line: 3,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('', 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'emptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt(' ', 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'emptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt(\`\`, 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'emptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt(\` \`, 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'emptyString',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbs('', 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'emptyString',
-          line: 2,
-        },
-      ],
     },
   ],
 });

--- a/packages/eslint-plugin-fbtee/src/__tests__/no-unhelpful-desc-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-unhelpful-desc-test.tsx
@@ -1,0 +1,313 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+
+// eslint-disable-next-line import/no-unresolved
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from '../rules/no-unhelpful-desc.tsx';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('unhelpful-desc', rule, {
+  valid: [
+    // <fbt>
+    {
+      code: `
+        <fbt desc="Greeting">Hello world</fbt>;
+      `,
+    },
+    {
+      code: `
+        <fbt desc={'Greeting'}>Hello</fbt>;
+      `,
+    },
+    {
+      code: `
+        <fbt desc={\`Greeting\`}>Hello</fbt>;
+      `,
+    },
+    {
+      code: `
+        <fbt
+          desc={
+            'A very long multiline description that ' +
+            'is spanning multiple lines.'
+          }
+        >
+          Hello
+        </fbt>;
+      `,
+    },
+    {
+      code: `
+        const description = 'Greeting';
+        <fbt desc={description}>Hello</fbt>;
+      `,
+    },
+    {
+      code: `
+        function getDescription() {
+          return 'Greeting';
+        }
+        <fbt desc={getDescription()}>Hello</fbt>;
+      `,
+    },
+
+    // fbt()
+    {
+      code: `
+        fbt('Hello world', 'Greeting');
+      `,
+    },
+    {
+      code: `
+        fbt('Hello world', \`Greeting\`);
+      `,
+    },
+    {
+      code: `
+        fbt(
+          'Hello world', 
+          'A very long multiline description that ' +
+          'is spanning multiple lines.'
+        );
+      `,
+    },
+
+    // fbs()
+    {
+      code: `
+        fbs('Hello world', 'Greeting');
+      `,
+    },
+    {
+      code: `
+        <input placeholder={fbs('Hello world', 'Greeting')} />;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // <fbt>
+      code: `
+        <fbt desc="">Hello</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'jsxEmptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={''}>Hello</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'jsxEmptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">Greeting</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Greeting'}>Greeting</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Greeting' + ''}>Greeting</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="greeting">Greeting</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Hey">Hello world</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'shortDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Hey'}>Hello world</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'shortDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Hey' + ''}>Hello world</fbt>;
+      `,
+      errors: [
+        {
+          messageId: 'shortDesc',
+          line: 2,
+        },
+      ],
+    },
+
+    // fbt()
+    {
+      code: `
+        fbt('Hello world', '');
+      `,
+      errors: [
+        {
+          messageId: 'emptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', \`\`);
+      `,
+      errors: [
+        {
+          messageId: 'emptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', '' + '');
+      `,
+      errors: [
+        {
+          messageId: 'emptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', 'Hey');
+      `,
+      errors: [
+        {
+          messageId: 'shortDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Greeting', 'Greeting');
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Greeting', 'greeting');
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+
+    // fbs()
+    {
+      code: `
+        fbs('Hello world', '');
+      `,
+      errors: [
+        {
+          messageId: 'emptyDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbs('Hello world', 'a');
+      `,
+      errors: [
+        {
+          messageId: 'shortDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        fbs('Hello world', 'Hello world');
+      `,
+      errors: [
+        {
+          messageId: 'duplicateDesc',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        <input 
+          placeholder={fbs('Hello world', '')} 
+        />;
+      `,
+      errors: [
+        {
+          messageId: 'emptyDesc',
+          line: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-fbtee/src/__tests__/no-unhelpful-desc-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-unhelpful-desc-test.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
-
-// eslint-disable-next-line import/no-unresolved
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import rule from '../rules/no-unhelpful-desc.tsx';
 
@@ -15,6 +12,224 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('unhelpful-desc', rule, {
+  invalid: [
+    {
+      // <fbt>
+      code: `
+        <fbt desc="">Hello</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={''}>Hello</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">Greeting</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Greeting'}>Greeting</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Greeting' + ''}>Greeting</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="greeting">Greeting</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Hey">Hello world</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'shortDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Hey'}>Hello world</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'shortDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc={'Hey' + ''}>Hello world</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'shortDesc',
+        },
+      ],
+    },
+
+    // fbt()
+    {
+      code: `
+        fbt('Hello world', '');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', \`\`);
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', '' + '');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Hello world', 'Hey');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'shortDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Greeting', 'Greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbt('Greeting', 'greeting');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+
+    // fbs()
+    {
+      code: `
+        fbs('Hello world', '');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'emptyDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbs('Hello world', 'a');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'shortDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        fbs('Hello world', 'Hello world');
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'duplicateDesc',
+        },
+      ],
+    },
+    {
+      code: `
+        <input 
+          placeholder={fbs('Hello world', '')} 
+        />;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'emptyDesc',
+        },
+      ],
+    },
+  ],
   valid: [
     // <fbt>
     {
@@ -90,224 +305,6 @@ ruleTester.run('unhelpful-desc', rule, {
       code: `
         <input placeholder={fbs('Hello world', 'Greeting')} />;
       `,
-    },
-  ],
-  invalid: [
-    {
-      // <fbt>
-      code: `
-        <fbt desc="">Hello</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc={''}>Hello</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'jsxEmptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Greeting">Greeting</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc={'Greeting'}>Greeting</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc={'Greeting' + ''}>Greeting</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="greeting">Greeting</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc="Hey">Hello world</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'shortDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc={'Hey'}>Hello world</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'shortDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <fbt desc={'Hey' + ''}>Hello world</fbt>;
-      `,
-      errors: [
-        {
-          messageId: 'shortDesc',
-          line: 2,
-        },
-      ],
-    },
-
-    // fbt()
-    {
-      code: `
-        fbt('Hello world', '');
-      `,
-      errors: [
-        {
-          messageId: 'emptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('Hello world', \`\`);
-      `,
-      errors: [
-        {
-          messageId: 'emptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('Hello world', '' + '');
-      `,
-      errors: [
-        {
-          messageId: 'emptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('Hello world', 'Hey');
-      `,
-      errors: [
-        {
-          messageId: 'shortDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('Greeting', 'Greeting');
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbt('Greeting', 'greeting');
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-
-    // fbs()
-    {
-      code: `
-        fbs('Hello world', '');
-      `,
-      errors: [
-        {
-          messageId: 'emptyDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbs('Hello world', 'a');
-      `,
-      errors: [
-        {
-          messageId: 'shortDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        fbs('Hello world', 'Hello world');
-      `,
-      errors: [
-        {
-          messageId: 'duplicateDesc',
-          line: 2,
-        },
-      ],
-    },
-    {
-      code: `
-        <input 
-          placeholder={fbs('Hello world', '')} 
-        />;
-      `,
-      errors: [
-        {
-          messageId: 'emptyDesc',
-          line: 3,
-        },
-      ],
     },
   ],
 });

--- a/packages/eslint-plugin-fbtee/src/index.tsx
+++ b/packages/eslint-plugin-fbtee/src/index.tsx
@@ -1,5 +1,6 @@
 import packageJson from '../package.json' with { type: 'json' };
 import noEmptyStringsRule from './rules/no-empty-strings.tsx';
+import noUnhelpfulDesc from './rules/no-unhelpful-desc.tsx';
 
 export const meta = {
   name: packageJson.name,
@@ -8,4 +9,5 @@ export const meta = {
 
 export const rules = {
   'no-empty-strings': noEmptyStringsRule,
+  'no-unhelpful-desc': noUnhelpfulDesc,
 };

--- a/packages/eslint-plugin-fbtee/src/rules/no-empty-strings.tsx
+++ b/packages/eslint-plugin-fbtee/src/rules/no-empty-strings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import type { TSESTree } from '@typescript-eslint/utils';
-import { createRule, elementType } from '../utils.tsx';
+import { createRule, elementType, resolveNodeValue } from '../utils.tsx';
 
 export default createRule<[], 'emptyString' | 'jsxEmptyString'>({
   name: 'no-empty-strings',
@@ -104,12 +104,5 @@ function validateChildren(
 }
 
 function isEmptyString(node: TSESTree.Expression | TSESTree.Literal): boolean {
-  if (node.type === 'Literal' && typeof node.value === 'string') {
-    return node.value.trim() === '';
-  }
-  return (
-    node.type === 'TemplateLiteral' &&
-    node.quasis.length === 1 &&
-    node.quasis[0].value.raw.trim() === ''
-  );
+  return resolveNodeValue(node)?.trim() === '';
 }

--- a/packages/eslint-plugin-fbtee/src/rules/no-unhelpful-desc.tsx
+++ b/packages/eslint-plugin-fbtee/src/rules/no-unhelpful-desc.tsx
@@ -1,0 +1,124 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+import {
+  createRule,
+  elementType,
+  resolveJsxElementTextContent,
+  resolveNodeValue,
+} from '../utils.tsx';
+
+export default createRule<
+  [],
+  'emptyDesc' | 'jsxEmptyDesc' | 'duplicateDesc' | 'shortDesc'
+>({
+  name: 'no-unhelpful-desc',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Enforce meaningful and non-empty descriptions in <fbt> elements and fbt()/fbs() function calls.',
+    },
+    messages: {
+      jsxEmptyDesc: 'The "desc" attribute in <fbt> must not be empty.',
+      emptyDesc: 'The "desc" argument in fbt() and fbs() must not be empty.',
+      duplicateDesc:
+        'The "desc" attribute or argument should not be a duplicate of the text content.',
+      shortDesc:
+        'The "desc" attribute or argument is too short. Use a more descriptive and meaningful explanation.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (elementType(node.parent.parent) !== 'fbt') {
+          return;
+        }
+
+        if (node.name.name !== 'desc' || !node.value) {
+          return;
+        }
+
+        if (
+          node.value.type === 'JSXExpressionContainer' &&
+          (node.value.expression.type === 'Identifier' ||
+            node.value.expression.type === 'CallExpression')
+        ) {
+          return;
+        }
+
+        const desc = resolveNodeValue(node.value)?.trim();
+
+        if (!desc) {
+          context.report({
+            node: node.value,
+            messageId: 'jsxEmptyDesc',
+          });
+          return;
+        }
+
+        if (desc.length <= 4) {
+          context.report({
+            node: node.value,
+            messageId: 'shortDesc',
+          });
+          return;
+        }
+
+        const textContent = resolveJsxElementTextContent(node.parent.parent);
+
+        if (desc.toLowerCase() === textContent.toLowerCase()) {
+          context.report({
+            node: node.value,
+            messageId: 'duplicateDesc',
+          });
+        }
+      },
+
+      CallExpression(node) {
+        if (
+          node.callee.type !== 'Identifier' ||
+          !(node.callee.name === 'fbt' || node.callee.name === 'fbs')
+        ) {
+          return;
+        }
+
+        const [textArg, descArg] = node.arguments;
+
+        const desc =
+          descArg && descArg.type !== 'SpreadElement'
+            ? resolveNodeValue(descArg)?.trim()
+            : null;
+
+        if (!desc) {
+          context.report({
+            node: descArg || node,
+            messageId: 'emptyDesc',
+          });
+          return;
+        }
+
+        if (desc.length <= 4) {
+          context.report({
+            node: descArg || node,
+            messageId: 'shortDesc',
+          });
+          return;
+        }
+
+        const text =
+          textArg && textArg.type !== 'SpreadElement'
+            ? resolveNodeValue(textArg)?.trim()
+            : null;
+
+        if (desc.toLowerCase() === text?.toLowerCase()) {
+          context.report({
+            node: descArg || node,
+            messageId: 'duplicateDesc',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-fbtee/src/utils.tsx
+++ b/packages/eslint-plugin-fbtee/src/utils.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import { ESLintUtils } from '@typescript-eslint/utils';
 import type { TSESTree } from '@typescript-eslint/utils';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,12 +144,12 @@ importers:
       '@babel/preset-react':
         specifier: ^7.26.3
         version: 7.26.3(@babel/core@7.26.0)
+      '@nkzw/eslint-plugin-fbtee':
+        specifier: workspace:^
+        version: link:../packages/eslint-plugin-fbtee
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.0.3(@types/node@22.10.2)(terser@5.36.0)(yaml@2.6.1))
-      eslint-plugin-fbtee:
-        specifier: workspace:^
-        version: link:../packages/eslint-plugin-fbtee
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@22.10.2)(terser@5.36.0)(yaml@2.6.1)


### PR DESCRIPTION
Stacked on #7 

Adds `no-unhelpful-desc` rule which checks if `desc` is an empty string, duplicate of the text content or too short.