### PR TITLE
Add JSXEmptyExpression handling to no-empty-strings rule

### DIFF
--- a/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
@@ -73,6 +73,69 @@ ruleTester.run('no-empty-strings', rule, {
     },
     {
       code: `
+        <fbt desc="Greeting">{}</fbt>;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          {}
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          {null}
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          {undefined}
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
+        <fbt desc="Greeting">
+          {/* This is a comment */}
+        </fbt>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'jsxEmptyString',
+        },
+      ],
+    },
+    {
+      code: `
         <fbt desc="Greeting">
           <span></span>
         </fbt>;
@@ -202,6 +265,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
     },
     {
+      // only: true,
       code: `
         <fbt desc="Greeting">
           Apple{' '}Banana

--- a/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-empty-strings-test.tsx
@@ -66,7 +66,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -90,7 +90,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -103,7 +103,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -116,7 +116,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -129,7 +129,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -142,7 +142,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -155,7 +155,7 @@ ruleTester.run('no-empty-strings', rule, {
       `,
       errors: [
         {
-          line: 3,
+          line: 2,
           messageId: 'jsxEmptyString',
         },
       ],
@@ -265,7 +265,6 @@ ruleTester.run('no-empty-strings', rule, {
       `,
     },
     {
-      // only: true,
       code: `
         <fbt desc="Greeting">
           Apple{' '}Banana

--- a/packages/eslint-plugin-fbtee/src/rules/no-empty-strings.tsx
+++ b/packages/eslint-plugin-fbtee/src/rules/no-empty-strings.tsx
@@ -74,12 +74,25 @@ function validateChildren(
       }
     }
 
-    if (
-      child.type === 'JSXExpressionContainer' &&
-      child.expression.type !== 'JSXEmptyExpression'
-    ) {
+    if (child.type === 'JSXExpressionContainer') {
+      if (child.expression.type === 'JSXEmptyExpression') {
+        nodesToReport.add(child.expression);
+        continue;
+      }
+
+      // Ignore when a variable is used <fbt desc="Greeting">{dynamicValue}</fbt>
       if (
-        isEmptyString(child.expression) &&
+        child.expression.type === 'Identifier' &&
+        child.expression.name !== 'undefined'
+      ) {
+        hasTextContent = true;
+        continue;
+      }
+
+      const value = resolveNodeValue(child.expression)?.trim();
+
+      if (
+        !value &&
         (node.children.length === 1 ||
           node.children.every(
             (otherChild) =>
@@ -105,6 +118,7 @@ function validateChildren(
     }
 
     if (hasTextContent) {
+      nodesToReport.clear();
       break;
     }
   }


### PR DESCRIPTION
Minor fixes to catch `<fbt desc="greeting">{}</fbt>`, `<fbt desc="greeting">{null}</fbt>` etc


Also simplified the empty string detection a bit, now the `<fbt>` is reported instead of individual child nodes. I think it makes more logical sense, but let me know what you think

Before
<img width="870" alt="image" src="https://github.com/user-attachments/assets/5852b860-4c22-4460-98ad-ca3af9461c22" />


After
<img width="703" alt="image" src="https://github.com/user-attachments/assets/c21de3d8-1781-4db3-9233-47b0166a93db" />

