### PR TITLE
Add git line-ending config for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Resolving Git line ending issues for Windows
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
* Avoids having git detect lots of modified files on Windows due to CR/LF EOL differences.