### PR TITLE
Catch untranslated text in conditional and logical expressions

### DIFF
--- a/packages/eslint-plugin-fbtee/src/__tests__/no-untranslated-strings-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-untranslated-strings-test.tsx
@@ -72,7 +72,48 @@ ruleTester.run('no-untranslated-strings', rule, {
     },
     {
       code: `
-        <>Hello world</>
+        <>Hello world</>;
+       `,
+      errors: [
+        {
+          messageId: 'unwrappedString',
+        },
+      ],
+    },
+    {
+      code: `
+        <span>{foo ? 'bar' : 'baz'}</span>;
+       `,
+      errors: [
+        {
+          messageId: 'unwrappedString',
+        },
+      ],
+    },
+    {
+      code: `
+        <span>{foo ?? 'bar'}</span>;
+       `,
+      errors: [
+        {
+          messageId: 'unwrappedString',
+        },
+      ],
+    },
+    {
+      code: `
+        <span>{foo || 'bar'}</span>;
+       `,
+      errors: [
+        {
+          messageId: 'unwrappedString',
+        },
+      ],
+    },
+    {
+      code: `
+        const foo = true;
+        <span>{foo && 'bar'}</span>;
        `,
       errors: [
         {
@@ -217,6 +258,21 @@ ruleTester.run('no-untranslated-strings', rule, {
     {
       code: `
        foo.bar('Baz')
+       `,
+    },
+    {
+      code: `
+       const foo = isGreeting ? 'Hello' : 'Goodbye'
+       `,
+    },
+    {
+      code: `
+       const foo = helloGreeting ?? 'goodbye'
+       `,
+    },
+    {
+      code: `
+       const foo = helloGreeting || 'goodbye'
        `,
     },
   ],

--- a/packages/eslint-plugin-fbtee/src/utils.tsx
+++ b/packages/eslint-plugin-fbtee/src/utils.tsx
@@ -105,6 +105,20 @@ export function resolveNodeValue(
     return resolveNodeValue(node.expression);
   }
 
+  if (node.type === 'ConditionalExpression') {
+    const consequent = resolveNodeValue(node.consequent);
+    const alternate = resolveNodeValue(node.alternate);
+
+    return consequent || alternate || null;
+  }
+
+  if (node.type === 'LogicalExpression') {
+    const left = resolveNodeValue(node.left);
+    const right = resolveNodeValue(node.right);
+
+    return left || right || null;
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Catch untranslated text in ternaries or logical expressions, e.g

```tsx
<span>{foo ? 'Bar' : 'Baz'}</span>
```

or

```tsx
<span>{foo ??  'Bar'}</span>
```