### PR TITLE
Remove use of testSection util for snapshots

### DIFF
--- a/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtAutoWrap-test.tsx.snap
+++ b/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtAutoWrap-test.tsx.snap
@@ -998,7 +998,7 @@ fbt._(
 
 `;
 
-exports[`Test jsx auto-wrapping of implicit parameters should wrap a string next to an explicit <fbt:param> that has a implicit <fbt:param> within it 1`] = `
+exports[`Test jsx auto-wrapping of implicit parameters should wrap a string next to an explicit <fbt:param> that has an implicit <fbt:param> within it 1`] = `
 import { fbt } from "fbtee";
 fbt._(
   /* __FBT__ start */ {

--- a/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/jsx-test.tsx.snap
+++ b/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/jsx-test.tsx.snap
@@ -311,7 +311,7 @@ var x = fbt._(
 
 `;
 
-exports[`Test declarative (jsx) fbt syntax translation should handle single expression with concentated strings 1`] = `
+exports[`Test declarative (jsx) fbt syntax translation should handle single expression with concatenated strings 1`] = `
 import { fbt } from "fbtee";
 fbt._(
   /* __FBT__ start */ {
@@ -506,7 +506,7 @@ fbt._(
 
 `;
 
-exports[`Test declarative (jsx) fbt syntax translation should support non-breasking space character 1`] = `
+exports[`Test declarative (jsx) fbt syntax translation should support non-breaking space character 1`] = `
 import { fbt } from "fbtee";
 fbt._(
   /* __FBT__ start */ {

--- a/packages/babel-plugin-fbtee/src/__tests__/fbtAutoWrap-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/fbtAutoWrap-test.tsx
@@ -2,64 +2,72 @@ import { describe, expect } from '@jest/globals';
 import {
   jsCodeFbtCallSerializer,
   snapshotTransform,
-  testSection,
   withFbtImportStatement,
 } from './FbtTestUtil.tsx';
 
 expect.addSnapshotSerializer(jsCodeFbtCallSerializer);
 
-const testData = {
-  'can handle multiple variations in nested strings': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        Level 1
-        <fbt:param name="foo">
-          {foo}
-        </fbt:param>
-        <a>
-          Level 2
-          <fbt:name name="bar" gender={g}>
-            {bar}
-          </fbt:name>
+describe('Test jsx auto-wrapping of implicit parameters', () => {
+  test('can handle multiple variations in nested strings', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            Level 1
+            <fbt:param name="foo">
+              {foo}
+            </fbt:param>
+            <a>
+              Level 2
+              <fbt:name name="bar" gender={g}>
+                {bar}
+              </fbt:name>
+    
+              <b>
+                Level 3
+                <fbt:plural
+                  name="baz"
+                  count={num}
+                  showCount="yes">
+                  cat
+                </fbt:plural>
+              </b>
+            </a>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-          <b>
-            Level 3
-            <fbt:plural
-              name="baz"
-              count={num}
-              showCount="yes">
-              cat
-            </fbt:plural>
-          </b>
-        </a>
-      </fbt>`,
-    ),
-  },
+  test('can handle multiple variations in nested strings and a subject gender', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="description" subject={g0}>
+            Level 1
+            <a href="#new">
+              <fbt:pronoun type="possessive" gender={g1} /> some_pronoun
+            </a>
+            <b>
+              Level 2
+              <fbt:plural
+                name="foo"
+                count={num}
+                showCount="yes">
+                cat
+              </fbt:plural>
+            </b>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'can handle multiple variations in nested strings and a subject gender': {
-    input: withFbtImportStatement(
-      `<fbt desc="description" subject={g0}>
-        Level 1
-        <a href="#new">
-          <fbt:pronoun type="possessive" gender={g1} /> some_pronoun
-        </a>
-        <b>
-          Level 2
-          <fbt:plural
-            name="foo"
-            count={num}
-            showCount="yes">
-            cat
-          </fbt:plural>
-        </b>
-      </fbt>`,
-    ),
-  },
-
-  'can handle multiple variations in nested strings with substrings that look identical':
-    {
-      input: withFbtImportStatement(
-        `<fbt desc="description" subject={g0}>
+  test('can handle multiple variations in nested strings with substrings that look identical', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="description" subject={g0}>
           Level 1
           <a href="#new">
             {/* Substring A */}
@@ -73,275 +81,335 @@ const testData = {
             </a>
           </b>
         </fbt>`,
+        ),
       ),
-    },
+    ).toMatchSnapshot();
+  });
 
-  'prevent token name collisions among fbt constructs across all nesting levels (v1)':
-    {
-      input: withFbtImportStatement(
-        `<fbt desc="some-desc">
-          Level 1
-          <fbt:param name="foo">
-            {foo}
-          </fbt:param>
-          <a>
-            Level 2
-            <fbt:name name="foo" gender={g}>
+  test('prevent token name collisions among fbt constructs across all nesting levels (v1)', () => {
+    expect(() =>
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            Level 1
+            <fbt:param name="foo">
               {foo}
-            </fbt:name>
-          </a>
-        </fbt>`,
+            </fbt:param>
+            <a>
+              Level 2
+              <fbt:name name="foo" gender={g}>
+                {foo}
+              </fbt:name>
+            </a>
+          </fbt>`,
+        ),
       ),
+    ).toThrow("There's already a token called `foo` in this fbt call.");
+  });
 
-      throws: "There's already a token called `foo` in this fbt call.",
-    },
+  test('prevent token name collisions among fbt constructs across all nesting levels (v2)', () => {
+    expect(() =>
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            Level 1
+            <fbt:param name="bar">
+              {bar}
+            </fbt:param>
+            <a>
+              Level 2
+              <fbt:name name="foo" gender={g}>
+                {foo}
+              </fbt:name>
+              <b>
+                Level 3
+                <fbt:plural
+                  name="foo"
+                  count={num}
+                  showCount="yes">
+                  cat
+                </fbt:plural>
+              </b>
+            </a>
+          </fbt>`,
+        ),
+      ),
+    ).toThrow("There's already a token called `foo` in this fbt call.");
+  });
 
-  'prevent token name collisions among fbt constructs across all nesting levels (v2)':
-    {
-      input: withFbtImportStatement(
-        `<fbt desc="some-desc">
-          Level 1
-          <fbt:param name="bar">
-            {bar}
-          </fbt:param>
-          <a>
-            Level 2
-            <fbt:name name="foo" gender={g}>
-              {foo}
-            </fbt:name>
+  test('should auto wrap a simple test with a nested level', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <Link href="#">
+              Your friends
+              <b>liked</b>
+            </Link>
+            your video
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should auto wrap a simple test with one level', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <link href="#">Your friends</link>
+            liked your video
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should work with multiple <fbt> calls in one file', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<div>
+            <fbt desc="one">
+              <div href="#">first</div>
+              fbt call
+            </fbt>
+            <fbt desc="two">
+              <div href="#">second</div>
+              test
+            </fbt>
+          </div>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should wrap a <fbt> child nested in an explicit <fbt:param>', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <fbt:param name="explicit fbt param">
+              <div>
+                <fbt desc="d2">
+                  explicit fbt param
+                  <div>with a nested implicit param</div>
+                </fbt>
+              </div>
+            </fbt:param>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should wrap a <fbt> child next to an explicit <fbt:param>', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <fbt:param name="explicit param next to">
+              <div>
+                <fbt desc="d2">explicit param next to</fbt>
+              </div>
+            </fbt:param>
+            <div>an implicit param</div>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should wrap a single unwrapped <fbt> child and a string above', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
             <b>
-              Level 3
-              <fbt:plural
-                name="foo"
-                count={num}
-                showCount="yes">
-                cat
-              </fbt:plural>
+              This is
+              <link href="#">a nested</link>
             </b>
-          </a>
-        </fbt>`,
+            test
+          </fbt>;`,
+        ),
       ),
+    ).toMatchSnapshot();
+  });
 
-      throws: "There's already a token called `foo` in this fbt call.",
-    },
-
-  'should auto wrap a simple test with a nested level': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <Link href="#">
-          Your friends
-          <b>liked</b>
-        </Link>
-        your video
-      </fbt>;`,
-    ),
-  },
-
-  'should auto wrap a simple test with one level': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <link href="#">Your friends</link>
-        liked your video
-      </fbt>;`,
-    ),
-  },
-
-  'should work with multiple <fbt> calls in one file': {
-    input: withFbtImportStatement(
-      `<div>
-        <fbt desc="one">
-          <div href="#">first</div>
-          fbt call
-        </fbt>
-        <fbt desc="two">
-          <div href="#">second</div>
-          test
-        </fbt>
-      </div>;`,
-    ),
-  },
-
-  'should wrap a <fbt> child nested in an explicit <fbt:param>': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <fbt:param name="explicit fbt param">
-          <div>
-            <fbt desc="d2">
-              explicit fbt param
-              <div>with a nested implicit param</div>
-            </fbt>
-          </div>
-        </fbt:param>
-      </fbt>;`,
-    ),
-  },
-
-  'should wrap a <fbt> child next to an explicit <fbt:param>': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <fbt:param name="explicit param next to">
-          <div>
-            <fbt desc="d2">explicit param next to</fbt>
-          </div>
-        </fbt:param>
-        <div>an implicit param</div>
-      </fbt>;`,
-    ),
-  },
-
-  'should wrap a single unwrapped <fbt> child and a string above': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <b>
-          This is
-          <link href="#">a nested</link>
-        </b>
-        test
-      </fbt>;`,
-    ),
-  },
-
-  'should wrap a single unwrapped <fbt> child and a string below': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div href="#">this is</div>
-        a singly nested test
-      </fbt>;`,
-    ),
-  },
-
-  'should wrap a string next to an explicit <fbt:param> that has a implicit <fbt:param> within it':
-    {
-      input: withFbtImportStatement(
-        `<fbt desc="d">
-        outer string that should not appear in inner desc
-        <fbt:param name="explicit fbt param">
-          <div>
-            <fbt desc="d2">
-              explicit fbt param
-              <div>with a nested implicit param</div>
-            </fbt>
-          </div>
-        </fbt:param>
-      </fbt>;`,
+  test('should wrap a single unwrapped <fbt> child and a string below', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div href="#">this is</div>
+            a singly nested test
+          </fbt>;`,
+        ),
       ),
-    },
+    ).toMatchSnapshot();
+  });
 
-  'should wrap an outer and inner child': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div href="#">
-          <div href="#">this is</div>
-          a doubly
-        </div>
-        nested test
-      </fbt>;`,
-    ),
-  },
+  test('should wrap a string next to an explicit <fbt:param> that has an implicit <fbt:param> within it', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            outer string that should not appear in inner desc
+            <fbt:param name="explicit fbt param">
+              <div>
+                <fbt desc="d2">
+                  explicit fbt param
+                  <div>with a nested implicit param</div>
+                </fbt>
+              </div>
+            </fbt:param>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap explicit params nested in implicit params with []': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div>
-          this is a test
-          <fbt:param name="to make sure that explicit params under an implicit node">
-            <link>
-              <fbt desc="d2">
-                to make sure that explicit tags
-                <b>under an implicit node</b>
-              </fbt>
-            </link>
-          </fbt:param>
-          <fbt:param name="and ones that are next to each other">
-            <link>
-              <fbt desc="d3">
-                and ones that are next
-                <b>to each other</b>
-              </fbt>
-            </link>
-          </fbt:param>
-          under an implicit tag are wrapped with [ ]
-        </div>
-        <fbt:param name="but free standing ones are not">
-          <link>
-            <fbt desc="d3">
-              but free standing ones
-              <b>are not</b>
-            </fbt>
-          </link>
-        </fbt:param>
-      </fbt>;`,
-    ),
-  },
+  test('should wrap an outer and inner child', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div href="#">
+              <div href="#">this is</div>
+              a doubly
+            </div>
+            nested test
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap two children with one nested level': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div href="#">
-          <div href="#">this is</div>
-          a doubly
-        </div>
-        nested test
-        <div href="#">with an additional level</div>
-      </fbt>;`,
-    ),
-  },
+  test('should wrap explicit params nested in implicit params with []', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div>
+              this is a test
+              <fbt:param name="to make sure that explicit params under an implicit node">
+                <link>
+                  <fbt desc="d2">
+                    to make sure that explicit tags
+                    <b>under an implicit node</b>
+                  </fbt>
+                </link>
+              </fbt:param>
+              <fbt:param name="and ones that are next to each other">
+                <link>
+                  <fbt desc="d3">
+                    and ones that are next
+                    <b>to each other</b>
+                  </fbt>
+                </link>
+              </fbt:param>
+              under an implicit tag are wrapped with [ ]
+            </div>
+            <fbt:param name="but free standing ones are not">
+              <link>
+                <fbt desc="d3">
+                  but free standing ones
+                  <b>are not</b>
+                </fbt>
+              </link>
+            </fbt:param>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap two nested next to each other': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div href="#">
-          one
-          <div href="#">two</div>
-        </div>
-        <div href="#">
-          three
-          <div href="#">four</div>
-        </div>
-      </fbt>;`,
-    ),
-  },
+  test('should wrap two children with one nested level', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div href="#">
+              <div href="#">this is</div>
+              a doubly
+            </div>
+            nested test
+            <div href="#">with an additional level</div>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap two nested next to each other with an extra level': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div href="#">
-          one
-          <div href="#">
-            two
-            <div href="#">test</div>
-          </div>
-        </div>
-        <div href="#">
-          three
-          <div href="#">four</div>
-        </div>
-      </fbt>;`,
-    ),
-  },
+  test('should wrap two nested next to each other', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div href="#">
+              one
+              <div href="#">two</div>
+            </div>
+            <div href="#">
+              three
+              <div href="#">four</div>
+            </div>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap two unwrapped <fbt> children': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div>wrap once</div>
-        <div>wrap twice</div>
-      </fbt>;`,
-    ),
-  },
+  test('should wrap two nested next to each other with an extra level', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div href="#">
+              one
+              <div href="#">
+                two
+                <div href="#">test</div>
+              </div>
+            </div>
+            <div href="#">
+              three
+              <div href="#">four</div>
+            </div>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should wrap two unwrapped <fbt> children and 1 nested': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">
-        <div>
-          wrap once
-          <div>and also</div>
-        </div>
-        <div>wrap twice</div>
-        complicated
-      </fbt>;`,
-    ),
-  },
-};
+  test('should wrap two unwrapped <fbt> children', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div>wrap once</div>
+            <div>wrap twice</div>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-describe('Test jsx auto-wrapping of implicit parameters', () =>
-  testSection(testData, snapshotTransform, { matchSnapshot: true }));
+  test('should wrap two unwrapped <fbt> children and 1 nested', () => {
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `<fbt desc="d">
+            <div>
+              wrap once
+              <div>and also</div>
+            </div>
+            <div>wrap twice</div>
+            complicated
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/babel-plugin-fbtee/src/__tests__/fbtStaticJSModule-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/fbtStaticJSModule-test.tsx
@@ -5,7 +5,6 @@ import {
   jsCodeFbtCallSerializer,
   payload,
   snapshotTransform,
-  testSection,
   transform,
   withFbtImportStatement,
 } from './FbtTestUtil.tsx';
@@ -26,140 +25,163 @@ describe('fbt preserveWhitespace argument', () => {
   // Here we are intentionally testing for the wrong behavior. We will come
   // back and update the expected output after we fix space normalization.
   describe('should NOT preserve whitespaces that do not neighbor raw text', () => {
-    const snapshotTestData = {
-      'jsx elements and raw text': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <span>
-                Where do
-              </span>
-              <b>spaces</b>
-              <i>go?</i>
-              Good
-              <i>question</i>
-              !
-            </fbt>;
-        `),
-      },
-      'jsx elements and string variation arguments nested inside jsx element': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <a>OuterJsx1</a>
-              RawText
-              <b>OuterJsx2</b>
-              <b>
-                <i>InnerJsx1</i>
-                <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
-                <i>InnerJsx2</i>
-              </b>
-            </fbt>;
-        `),
-      },
-      'jsx elements with string variation arguments': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <span>
-                There should be
-              </span>
-              <b>
-                <fbt:plural
-                  many="spaces"
-                  showCount="ifMany"
-                  count={this.state.ex1Count}>
-                  a space
-                </fbt:plural>
-              </b>
-              !
-            </fbt>;
-        `),
-      },
-      'should not preserve whitespace around text in JSXExpression': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <a>OuterJsx1</a>
-              {'textInJSXExpression'}
-              <b>OuterJsx2</b>
-              <b>
-                rawText
+    it('jsx elements and raw text', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <span>
+                  Where do
+                </span>
+                <b>spaces</b>
+                <i>go?</i>
+                Good
+                <i>question</i>
+                !
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('jsx elements and string variation arguments nested inside jsx element', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <a>OuterJsx1</a>
+                RawText
+                <b>OuterJsx2</b>
+                <b>
+                  <i>InnerJsx1</i>
+                  <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
+                  <i>InnerJsx2</i>
+                </b>
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('jsx elements with string variation arguments', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <span>
+                  There should be
+                </span>
+                <b>
+                  <fbt:plural
+                    many="spaces"
+                    showCount="ifMany"
+                    count={this.state.ex1Count}>
+                    a space
+                  </fbt:plural>
+                </b>
+                !
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should not preserve whitespace around text in JSXExpression', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <a>OuterJsx1</a>
                 {'textInJSXExpression'}
-                <i>InnerJsx1</i>
-                {'textInJSXExpression'}
-                <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
-                {'text' + 'InJSXExpression'}
-                <i>InnerJsx2</i>
-                {\`text${'InJSXExpression'}\`}
-              </b>
-            </fbt>;
-        `),
-      },
-      'should preserve voluntarily added spaces between NON-raw text': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <a>OuterJsx1</a>
-              {' '}
-              <b>OuterJsx2</b>
-              <b>
+                <b>OuterJsx2</b>
+                <b>
+                  rawText
+                  {'textInJSXExpression'}
+                  <i>InnerJsx1</i>
+                  {'textInJSXExpression'}
+                  <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
+                  {'text' + 'InJSXExpression'}
+                  <i>InnerJsx2</i>
+                  {\`text${'InJSXExpression'}\`}
+                </b>
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should preserve voluntarily added spaces between NON-raw text', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <a>OuterJsx1</a>
                 {' '}
-                <i>InnerJsx1</i>
-                {' '}
-                <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
-                {' '}
-                <i>InnerJsx2</i>
-                {' '}
-                <i>InnerJsx3</i>
-                {' '}
-              </b>
-            </fbt>;
-        `),
-      },
-      'should treat comments in JSXExpression like they are not here': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              <a>OuterJsx1</a>
-              {/* someComment */}
-              <b>OuterJsx2</b>
-              <b>
+                <b>OuterJsx2</b>
+                <b>
+                  {' '}
+                  <i>InnerJsx1</i>
+                  {' '}
+                  <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
+                  {' '}
+                  <i>InnerJsx2</i>
+                  {' '}
+                  <i>InnerJsx3</i>
+                  {' '}
+                </b>
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should treat comments in JSXExpression like they are not here', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                <a>OuterJsx1</a>
                 {/* someComment */}
-                <i>InnerJsx1</i>
-                {/* someComment */}
-                <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
-                {/* someComment */}
-                rawText
-              </b>
-            </fbt>;
-        `),
-      },
-    };
-    testSection(snapshotTestData, snapshotTransform, {
-      matchSnapshot: true,
+                <b>OuterJsx2</b>
+                <b>
+                  {/* someComment */}
+                  <i>InnerJsx1</i>
+                  {/* someComment */}
+                  <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
+                  {/* someComment */}
+                  rawText
+                </b>
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
     });
   });
 
   describe('should preserve whitespace around text', () => {
-    const snapshotTestData = {
-      'with inner text and string variation': {
-        input: withFbtImportStatement(`
-          var x =
-            <fbt desc="d">
-              outerText
-              <a>outerJsx</a>
-              <b>
-                <i>innerJsx</i>
-                innerText
-                <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
-              </b>
-            </fbt>;
-        `),
-      },
-    };
-    testSection(snapshotTestData, snapshotTransform, {
-      matchSnapshot: true,
+    it('with inner text and string variation', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            var x =
+              <fbt desc="d">
+                outerText
+                <a>outerJsx</a>
+                <b>
+                  <i>innerJsx</i>
+                  innerText
+                  <fbt:plural count={this.state.ex1Count}>(plural)</fbt:plural>
+                </b>
+              </fbt>;
+          `),
+        ),
+      ).toMatchSnapshot();
     });
   });
 

--- a/packages/babel-plugin-fbtee/src/__tests__/jsx-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/jsx-test.tsx
@@ -2,465 +2,593 @@ import { describe, expect, it, test } from '@jest/globals';
 import {
   jsCodeFbtCallSerializer,
   snapshotTransformKeepJsx,
-  testSectionAsync,
   withFbtImportStatement,
 } from './FbtTestUtil.tsx';
 
 expect.addSnapshotSerializer(jsCodeFbtCallSerializer);
 
-const testData = {
-  'Enable explicit whitespace': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="squelched">
-        <fbt:param name="one">{one}</fbt:param>
-        {" "}
-        <fbt:param name="two">{two}</fbt:param>
-        {\` \`}
-        <fbt:param name="three">{three}</fbt:param>
-      </fbt>;`,
-    ),
-  },
-
-  'Squelch whitespace when in an expression': {
-    input: withFbtImportStatement(
-      `var x =
-        <fbt desc="squelched">
-          {"Squelched white space... "}
-          with some
-          {' other stuff.'}
-        </fbt>;
-        baz();`,
-    ),
-  },
-
-  'fbt:param with multiple children should error': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        <fbt:param name="foo">
-          {foo}
-          {bar}
-        </fbt:param>
-      </fbt>`,
-    ),
-
-    throws: `fbt:param expects an {expression} or JSX element, and only one`,
-  },
-
-  'fbt:param with multiple empty expression containers should be ok': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        <fbt:param name="foo">
-          {}
-          {/* comment */}
-          {foo}
-          {}
-        </fbt:param>
-      </fbt>`,
-    ),
-  },
-
-  'should be able to house arbitrary markup within fbt:param nodes': {
-    input: withFbtImportStatement(
-      `<div>
-        <fbt desc="...">
-          <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
-           by
-          <fbt:param name="user name">
-            <Link href={{url:user.link}}>
-              {user.name}
-            </Link>
-          </fbt:param>
-        </fbt>
-      </div>;`,
-    ),
-  },
-
-  'should be able to nest within React nodes': {
-    input: withFbtImportStatement(
-      `var x = <div>
-        <fbt desc="nested!">
-          A nested string
-        </fbt>
-      </div>;`,
-    ),
-  },
-
-  'should convert simple strings': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="It's simple">A simple string</fbt>;`,
-    ),
-  },
-
-  'should correctly destruct expression values in options': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">str
-        <fbt:param name="count" number={someNum}>
-          {getNum()}
-        </fbt:param>
-      </fbt>`,
-    ),
-  },
-
-  'should filter comment and empty expressions from children': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="It's simple">
-        {
-        }A sim{/*
-          ignore
-          me
-          */}ple s{ }tri{}ng{/*ignore me*/}</fbt>;`,
-    ),
-  },
-
-  'should handle common string': {
-    input: withFbtImportStatement(`<fbt common={true}>Done</fbt>`),
-
-    options: {
-      fbtCommon: { Done: 'The description for the common string "Done"' },
-    },
-  },
-
-  'should handle concatenated descriptions': {
-    input: withFbtImportStatement(
-      `<fbt desc={"A very long description " + "that we will concatenate " +
-        "a few times"}
-        project={"With" + "a" + "project"}>
-        Here it is
-      </fbt>;`,
-    ),
-  },
-
-  'should handle empty string': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="a message!">
-        A parameterized message to:
-        <fbt:param name="emptyString"> </fbt:param>
-      </fbt>;`,
-    ),
-  },
-
-  'should handle enums (with array values)': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="enums!">
-        Click to see
-        <fbt:enum
-          enum-range={[
-            "groups",
-            "photos",
-            "videos"
-          ]}
-          value={id}
-        />
-      </fbt>;`,
-    ),
-  },
-
-  'should handle enums (with object values)': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="enums!">
-        Click to see
-        <fbt:enum
-          enum-range={{
-            id1: "groups",
-            id2: "photos",
-            id3: "videos"
-          }}
-          value={id}
-        />
-      </fbt>;`,
-    ),
-  },
-
-  'should handle enums with more text': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="enums!">
-        Click to see
-        <fbt:enum
-          enum-range={{
-            id1: "groups",
-            id2: "photos",
-            id3: "videos"
-          }}
-          value={id}
-        />
-        Hey-hey!
-      </fbt>;`,
-    ),
-  },
-
-  'should handle fbt common attribute without value': {
-    input: withFbtImportStatement(`<fbt common>Okay</fbt>`),
-
-    options: {
-      fbtCommon: { Okay: 'The description for the common string "Okay"' },
-    },
-  },
-
-  'should handle number={true} - (same output as above test)': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="variations!">
-        Click to see
-        <fbt:param name="count" number={true}>{c}</fbt:param>
-        links
-      </fbt>;`,
-    ),
-  },
-
-  'should handle object pronoun': {
-    input: withFbtImportStatement(
-      `<fbt desc={"d"} project={"p"}>
-          I know <fbt:pronoun type="object" gender={gender}/>.
-        </fbt>;`,
-    ),
-  },
-
-  'should handle params': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="a message!">
-          A parameterized message to:
-          <fbt:param name="personName">{theName}</fbt:param>
-        </fbt>;`,
-    ),
-  },
-
-  'should handle single expression with concentated strings': {
-    input: withFbtImportStatement(
-      `<fbt desc="foo">
-        {"foo" + "bar"}
-      </fbt>`,
-    ),
-  },
-
-  'should handle subject+reflexive pronouns': {
-    input:
-      // She wished herself a happy birthday.
-      withFbtImportStatement(
-        `<fbt desc={"d"} project={"p"}>
-          <fbt:pronoun type="subject" gender={gender} capitalize={true} human={true}/>
-          wished <fbt:pronoun type="reflexive" gender={gender} human={true}/> a happy birthday.
-        </fbt>;`,
+describe('Test declarative (jsx) fbt syntax translation', () => {
+  test('Enable explicit whitespace', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="squelched">
+            <fbt:param name="one">{one}</fbt:param>
+            {" "}
+            <fbt:param name="two">{two}</fbt:param>
+            {\` \`}
+            <fbt:param name="three">{three}</fbt:param>
+          </fbt>;`,
+        ),
       ),
-  },
+    ).toMatchSnapshot();
+  });
 
-  'should handle template descriptions': {
-    input: withFbtImportStatement(
-      `<fbt desc={\`A very long description
-        that will be a
-        template across multiple lines\`}
-        project={"With" + "a" + "project"}>
-        Here it is
-      </fbt>;`,
-    ),
-  },
+  test('Squelch whitespace when in an expression', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x =
+            <fbt desc="squelched">
+              {"Squelched white space... "}
+              with some
+              {' other stuff.'}
+            </fbt>;
+            baz();`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should handle variations': {
-    input: withFbtImportStatement(
-      `var x = <fbt desc="variations!">
-        Click to see
-        <fbt:param name="count" number="true">{c}</fbt:param>
-        links
-      </fbt>;`,
-    ),
-  },
+  test('fbt:param with multiple children should error', () => {
+    expect(() =>
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            <fbt:param name="foo">
+              {foo}
+              {bar}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toThrow(`fbt:param expects an {expression} or JSX element, and only one`);
+  });
 
-  'should ignore __private attributes': {
-    input: withFbtImportStatement(
-      `<fbt __self="fbt" desc="some-desc">
-        <fbt:param __self="param" name="foo">
-          {foo}
-        </fbt:param>
-      </fbt>`,
-    ),
-  },
+  test('fbt:param with multiple empty expression containers should be ok', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            <fbt:param name="foo">
+              {}
+              {/* comment */}
+              {foo}
+              {}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should ignore non-expression children in fbt:param': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        <fbt:param name="foo">
-          !{foo}!
-        </fbt:param>
-      </fbt>`,
-    ),
-  },
+  test('should be able to house arbitrary markup within fbt:param nodes', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<div>
+            <fbt desc="...">
+              <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
+                by
+              <fbt:param name="user name">
+                <Link href={{url:user.link}}>
+                  {user.name}
+                </Link>
+              </fbt:param>
+            </fbt>
+          </div>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should insert param value for same-param': {
-    input: withFbtImportStatement(
-      `<fbt desc="d">str
-        <fbt:param name="foo">{Bar}</fbt:param> and
-        <fbt:same-param name="foo"/>
-      </fbt>`,
-    ),
-  },
+  test('should be able to nest within React nodes', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <div>
+              <fbt desc="nested!">
+                A nested string
+              </fbt>
+            </div>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should maintain order of params and enums': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        Hello,
-        <fbt:param name="foo">
-          {foo}
-        </fbt:param>
-        <fbt:enum enum-range={["x", "y"]} value={x} />
-        <fbt:param name="bar" number={n}>
-          {bar}
-        </fbt:param>
-      </fbt>`,
-    ),
-  },
+  test('should convert simple strings', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="It's simple">A simple string</fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should not insert extra space': {
-    input: withFbtImportStatement(
-      `<fbt desc="Greating in i18n demo">
-        Hello, <fbt:param name="guest">
-          {guest}
-        </fbt:param>!
-      </fbt>`,
-    ),
-  },
+  test('should correctly destruct expression values in options', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="d">str
+            <fbt:param name="count" number={someNum}>
+              {getNum()}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should strip out more newlines': {
-    input: withFbtImportStatement(
-      `var x =
-        <fbt desc="moar lines">
-          A simple string...
-          with some other stuff.
-        </fbt>;
-        baz();`,
-    ),
-  },
+  test('should filter comment and empty expressions from children', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="It's simple">
+            {
+            }A sim{/*
+              ignore
+              me
+              */}ple s{ }tri{}ng{/*ignore me*/}</fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should strip out newlines': {
-    input: withFbtImportStatement(
-      `var x =
-        <fbt desc="Test trailing space when not last child">
-          Preamble
-          <fbt:param name="parm">{blah}</fbt:param>
-        </fbt>;
-      baz();`,
-    ),
-  },
+  test('should handle common string', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(`<fbt common={true}>Done</fbt>`),
+        { fbtCommon: { Done: 'The description for the common string "Done"' } },
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should support html escapes': {
-    input: withFbtImportStatement(
-      `<fbt desc="foo &quot;bar&quot;">&times;</fbt>`,
-    ),
-  },
+  test('should handle concatenated descriptions', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc={"A very long description " + "that we will concatenate " +
+            "a few times"}
+            project={"With" + "a" + "project"}>
+            Here it is
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should support non-breasking space character': {
+  test('should handle empty string', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="a message!">
+            A parameterized message to:
+            <fbt:param name="emptyString"> </fbt:param>
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle enums (with array values)', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="enums!">
+            Click to see
+            <fbt:enum
+              enum-range={[
+                "groups",
+                "photos",
+                "videos"
+              ]}
+              value={id}
+            />
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle enums (with object values)', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="enums!">
+              Click to see
+              <fbt:enum
+                enum-range={{
+                  id1: "groups",
+                  id2: "photos",
+                  id3: "videos"
+                }}
+                value={id}
+              />
+            </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle enums with more text', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="enums!">
+            Click to see
+            <fbt:enum
+              enum-range={{
+                id1: "groups",
+                id2: "photos",
+                id3: "videos"
+              }}
+              value={id}
+            />
+            Hey-hey!
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle fbt common attribute without value', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(`<fbt common>Okay</fbt>`),
+        { fbtCommon: { Okay: 'The description for the common string "Okay"' } },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle number={true} - (same output as above test)', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="variations!">
+            Click to see
+            <fbt:param name="count" number={true}>{c}</fbt:param>
+            links
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle object pronoun', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc={"d"} project={"p"}>
+            I know <fbt:pronoun type="object" gender={gender}/>.
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle params', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="a message!">
+              A parameterized message to:
+              <fbt:param name="personName">{theName}</fbt:param>
+            </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle single expression with concatenated strings', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="foo">
+            {"foo" + "bar"}
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle subject+reflexive pronouns', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc={"d"} project={"p"}>
+            <fbt:pronoun type="subject" gender={gender} capitalize={true} human={true}/>
+            wished <fbt:pronoun type="reflexive" gender={gender} human={true}/> a happy birthday.
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle template descriptions', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc={\`A very long description
+            that will be a
+            template across multiple lines\`}
+            project={"With" + "a" + "project"}>
+            Here it is
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should handle variations', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x = <fbt desc="variations!">
+            Click to see
+            <fbt:param name="count" number="true">{c}</fbt:param>
+            links
+          </fbt>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should ignore __private attributes', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt __self="fbt" desc="some-desc">
+            <fbt:param __self="param" name="foo">
+              {foo}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should ignore non-expression children in fbt:param', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            <fbt:param name="foo">
+              !{foo}!
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should insert param value for same-param', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="d">str
+            <fbt:param name="foo">{Bar}</fbt:param> and
+            <fbt:same-param name="foo"/>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should maintain order of params and enums', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            Hello,
+            <fbt:param name="foo">
+              {foo}
+            </fbt:param>
+            <fbt:enum enum-range={["x", "y"]} value={x} />
+            <fbt:param name="bar" number={n}>
+              {bar}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should not insert extra space', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="Greating in i18n demo">
+            Hello, <fbt:param name="guest">
+              {guest}
+            </fbt:param>!
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should strip out more newlines', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x =
+            <fbt desc="moar lines">
+              A simple string...
+              with some other stuff.
+            </fbt>;
+            baz();`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should strip out newlines', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `var x =
+            <fbt desc="Test trailing space when not last child">
+              Preamble
+              <fbt:param name="parm">{blah}</fbt:param>
+            </fbt>;
+          baz();`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should support html escapes', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(`<fbt desc="foo &quot;bar&quot;">&times;</fbt>`),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should support non-breaking space character', () => {
     // multiple spaces are normalized to a single space
     // but &nbsp characters are preserved
-    input: withFbtImportStatement(
-      `<fbt desc="desc with    non-breaking&nbsp;&nbsp;&nbsp;space">
-          text with    non-breaking&nbsp;&nbsp;&nbsp;space
-      </fbt>`,
-    ),
-  },
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="desc with    non-breaking&nbsp;&nbsp;&nbsp;space">
+              text with    non-breaking&nbsp;&nbsp;&nbsp;space
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should support unicode characters': {
-    input: withFbtImportStatement(
-      `// A backslash \\ in comments
-      <fbt desc="unicode characters">
-        A copyright sign {'\\u00A9'},
-        a multi byte character {'\\uD83D\\uDCA9'},
-        and a backslash {'\\\\'}.
-      </fbt>`,
-    ),
-  },
+  test('should support unicode characters', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `// A backslash \\ in comments
+          <fbt desc="unicode characters">
+            A copyright sign {'\\u00A9'},
+            a multi byte character {'\\uD83D\\uDCA9'},
+            and a backslash {'\\\\'}.
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should throw for fbt that has description and common attribute (without value)':
-    {
-      input: withFbtImportStatement(`<fbt common={true} desc='d'>No</fbt>`),
+  test('should throw for fbt that has description and common attribute (without value)', () => {
+    expect(() =>
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(`<fbt common={true} desc='d'>No</fbt>`),
+        { fbtCommon: { No: 'The description for the common string "No"' } },
+      ),
+    ).toThrow(`<fbt common> must not have "desc" attribute.`);
+  });
 
-      options: {
-        fbtCommon: { No: 'The description for the common string "No"' },
-      },
+  test('should throw for strings with `common` attribute equal to false', () => {
+    expect(() =>
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(`<fbt common={false}>Yes</fbt>`),
+        { fbtCommon: { Yes: 'The description for the common string "Yes"' } },
+      ),
+    ).toThrow(`This node requires a 'desc' attribute.`);
+  });
 
-      throws: `<fbt common> must not have "desc" attribute.`,
-    },
+  test('should throw on invalid attributes in fbt:param', () => {
+    expect(() =>
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="some-desc">
+            <fbt:param name="foo" qux="foo" desc="foo-desc">
+              {foo}
+            </fbt:param>
+          </fbt>`,
+        ),
+      ),
+    ).toThrow(`Invalid option "qux". Only allowed: gender, number, name`);
+  });
 
-  'should throw for strings with `common` attribute equal to false': {
-    input: withFbtImportStatement(`<fbt common={false}>Yes</fbt>`),
+  test('should throw on undefined common string', () => {
+    expect(() =>
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt common={true}>Some undefined common string</fbt>`,
+        ),
+        {},
+      ),
+    ).toThrow(
+      `Unknown string "Some undefined common string" for <fbt common={true}>`,
+    );
+  });
 
-    options: {
-      fbtCommon: { Yes: 'The description for the common string "Yes"' },
-    },
+  test('should treat multiline descs as a single line', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<fbt desc="hi how are you today im doing well i guess
+            how is your mother is she well yeah why not lets go
+            home and never come back.">
+            lol
+          </fbt>`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-    throws: `This node requires a 'desc' attribute.`,
-  },
+  test('should work with fragments', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<Fragment>
+            <fbt desc="...">
+              <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
+               by
+              <fbt:param name="user name">
+                <Link href={{url:user.link}}>
+                  {user.name}
+                </Link>
+              </fbt:param>
+            </fbt>
+          </Fragment>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 
-  'should throw on invalid attributes in fbt:param': {
-    input: withFbtImportStatement(
-      `<fbt desc="some-desc">
-        <fbt:param name="foo" qux="foo" desc="foo-desc">
-          {foo}
-        </fbt:param>
-      </fbt>`,
-    ),
-
-    throws: `Invalid option "qux". Only allowed: gender, number, name`,
-  },
-
-  'should throw on undefined common string': {
-    input: withFbtImportStatement(
-      `<fbt common={true}>Some undefined common string</fbt>`,
-    ),
-
-    options: {},
-
-    throws: `Unknown string "Some undefined common string" for <fbt common={true}>`,
-  },
-
-  'should treat multiline descs as a single line': {
-    input: withFbtImportStatement(
-      `<fbt desc="hi how are you today im doing well i guess
-        how is your mother is she well yeah why not lets go
-        home and never come back.">
-        lol
-      </fbt>`,
-    ),
-  },
-
-  'should work with fragments': {
-    input: withFbtImportStatement(
-      `<Fragment>
-        <fbt desc="...">
-          <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
-           by
-          <fbt:param name="user name">
-            <Link href={{url:user.link}}>
-              {user.name}
-            </Link>
-          </fbt:param>
-        </fbt>
-      </Fragment>;`,
-    ),
-  },
-
-  'should work with implicit fragments': {
-    input: withFbtImportStatement(
-      `<>
-        <fbt desc="...">
-          <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
-           by
-          <fbt:param name="user name">
-            <Link href={{url:user.link}}>
-              {user.name}
-            </Link>
-          </fbt:param>
-        </fbt>
-      </>;`,
-    ),
-  },
-};
-
-describe('Test declarative (jsx) fbt syntax translation', () =>
-  testSectionAsync(testData, snapshotTransformKeepJsx, {
-    matchSnapshot: true,
-  }));
+  test('should work with implicit fragments', () => {
+    expect(
+      snapshotTransformKeepJsx(
+        withFbtImportStatement(
+          `<>
+            <fbt desc="...">
+              <fbt:param name="time">{formatDate(date, "F d, Y")}</fbt:param>
+               by
+              <fbt:param name="user name">
+                <Link href={{url:user.link}}>
+                  {user.name}
+                </Link>
+              </fbt:param>
+            </fbt>
+          </>;`,
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+});
 
 describe('Test fbt transforms without the jsx transform', () => {
   it('not nested', async () => {
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         let x =
           <fbt desc="nested!">
@@ -473,7 +601,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
   it('nested in div', async () => {
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         let x =
           <div>
@@ -488,7 +616,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
   it('short bool syntax for doNotExtract attribute', async () => {
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         let x = <fbt desc="" doNotExtract>Test</fbt>;
       `),
@@ -498,7 +626,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
   it('short bool syntax for number attribute', async () => {
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         let x =
           <fbt desc="">
@@ -512,7 +640,7 @@ describe('Test fbt transforms without the jsx transform', () => {
   describe('when using within template literals', () => {
     it('should work with a basic <fbt>', async () => {
       expect(
-        await snapshotTransformKeepJsx(
+        snapshotTransformKeepJsx(
           withFbtImportStatement(`
           html\`<div>
             \${
@@ -528,7 +656,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
     it('should work with basic <fbt> auto-parameterization', async () => {
       expect(
-        await snapshotTransformKeepJsx(
+        snapshotTransformKeepJsx(
           withFbtImportStatement(`
           html\`<div>
             \${
@@ -547,7 +675,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
     it('should dedupe plurals', async () => {
       expect(
-        await snapshotTransformKeepJsx(
+        snapshotTransformKeepJsx(
           withFbtImportStatement(`
           <fbt desc="desc...">
             There
@@ -563,7 +691,7 @@ describe('Test fbt transforms without the jsx transform', () => {
 
     it('should work with a nested <fbt> within an <fbt:param>', async () => {
       expect(
-        await snapshotTransformKeepJsx(
+        snapshotTransformKeepJsx(
           withFbtImportStatement(`
           html\`<div>
             \${
@@ -595,7 +723,7 @@ describe('Test fbt transforms without the jsx transform', () => {
   // TODO: Fix preserving whitespace for JSX text.
   it('should fail to preserve whitespace in text when preserveWhitespace=true (known bug)', async () => {
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         <fbt desc="desc with 3   spaces" preserveWhitespace={true}>
           Some text with 3   spaces in between.
@@ -608,7 +736,7 @@ describe('Test fbt transforms without the jsx transform', () => {
   // TODO: We should NOT insert a space between two <fbt:plural>'s
   it(`[legacy buggy behavior] <fbt:pronoun> should insert a space character between two fbt constructs that don't neighbor raw text`, async () =>
     expect(
-      await snapshotTransformKeepJsx(
+      snapshotTransformKeepJsx(
         withFbtImportStatement(`
         <fbt desc="">
           You can add
@@ -630,14 +758,14 @@ test('Test common fbt with value-less `common` attribute should have same runtim
     fbtCommon: { Submit: 'The description for the common string "Submit"' },
   };
   expect(
-    await snapshotTransformKeepJsx(
+    snapshotTransformKeepJsx(
       withFbtImportStatement(`
         let x = <fbt common>Submit</fbt>;
       `),
       options,
     ),
   ).toEqual(
-    await snapshotTransformKeepJsx(
+    snapshotTransformKeepJsx(
       withFbtImportStatement(`
         let x = <fbt common={true}>Submit</fbt>;
       `),


### PR DESCRIPTION
Remove most usage of the `testSection` helper in favour of plain `describe` or `test` blocks

Recommend reviewing with [no whitespace diff](https://github.com/nkzw-tech/fbtee/pull/19/files?w=1)