### PR TITLE
fbt-runtime-test: it should only expect "missing translation" console warnings

### DIFF
--- a/packages/fbtee/src/__tests__/fbt-runtime-test.tsx
+++ b/packages/fbtee/src/__tests__/fbt-runtime-test.tsx
@@ -20,7 +20,9 @@ setupFbtee({
 });
 
 // Ignore missing translations.
-console.warn = jest.fn();
+console.warn = jest.fn().mockImplementation((message) => {
+  expect(message).toBe(`Translations have not been provided.`);
+});
 
 describe('fbt', () => {
   it('should handle variated numbers', () => {

--- a/packages/fbtee/src/__tests__/fbt-runtime-test.tsx
+++ b/packages/fbtee/src/__tests__/fbt-runtime-test.tsx
@@ -20,9 +20,7 @@ setupFbtee({
 });
 
 // Ignore missing translations.
-console.warn = jest.fn().mockImplementation((message) => {
-  expect(message).toBe(`Translations have not been provided.`);
-});
+console.warn = jest.fn();
 
 describe('fbt', () => {
   it('should handle variated numbers', () => {
@@ -47,6 +45,8 @@ describe('fbt', () => {
         { num: displayNumber },
       ]);
     }
+
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('should access table with fallback logic', () => {
@@ -139,5 +139,9 @@ describe('fbt', () => {
       { arg: [B, other, name], expected: 'B,FEMALE,OTHER Bob has 20' },
     ];
     tests.forEach(runTest);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Translations have not been provided.',
+    );
   });
 });


### PR DESCRIPTION
This will help detect any other unexpected runtime warning that might be thrown by the fbt library.