### PR TITLE
Use snapshots for fbtPronoun tests

### DIFF
--- a/packages/babel-plugin-fbtee-runtime/src/__tests__/__snapshots__/index-test.tsx.snap
+++ b/packages/babel-plugin-fbtee-runtime/src/__tests__/__snapshots__/index-test.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test enum hash keys generation should generate single hash key for fbt with enum under regular mode 1`] = `
+"import { fbt } from "fbtee";
+fbt._({
+  "a": "Foo A",
+  "b": "Foo B",
+  "c": "Foo C"
+}, [fbt._enum('a', {
+  "a": "A",
+  "b": "B",
+  "c": "C"
+})], {
+  hk: "NT3sR"
+});"
+`;
+
+exports[`Test hash key generation should auto import for <fbs> 1`] = `
+"import { fbs } from "fbtee";
+fbs._("test", null, {
+  hk: "2zCyVJ"
+});"
+`;
+
+exports[`Test hash key generation should auto import for <fbt> 1`] = `
+"import { fbt } from "fbtee";
+fbt._("{two lines} test", [fbt._param("two lines", /*#__PURE__*/React.createElement("b", null, fbt._("simple", null, {
+  hk: "2pjKFw"
+})))], {
+  hk: "2xRGl8"
+});"
+`;
+
+exports[`Test hash key generation should generate hash key for nested fbts 1`] = `
+"import { fbt } from "fbtee";
+fbt._("{two lines} test", [fbt._param("two lines", /*#__PURE__*/React.createElement("b", null, fbt._("simple", null, {
+  hk: "2pjKFw"
+})))], {
+  hk: "2xRGl8"
+});"
+`;
+
+exports[`Test hash key generation should generate hash key for simply string 1`] = `
+"import { fbt } from "fbtee";
+fbt._("Foo", null, {
+  hk: "3ktBJ2"
+});"
+`;
+
+exports[`Test replacing clear token names with mangled tokens 1`] = `
+"var fbt_sv_arg_0;
+import { fbt } from "fbtee";
+fbt_sv_arg_0 = fbt._plural(ex1.count, "number"), fbt._({
+  "*": "{=m0} friends {=m2}{number} photos",
+  "_1": "{=m0} friends {=m2} a photo"
+}, [fbt_sv_arg_0, fbt._implicitParam("=m0", /*#__PURE__*/React.createElement("b", null, fbt._({
+  "*": "Your",
+  "_1": "Your"
+}, [fbt_sv_arg_0], {
+  hk: "3AIVHA"
+}))), fbt._implicitParam("=m2", /*#__PURE__*/React.createElement("b", null, fbt._({
+  "*": "shared",
+  "_1": "shared"
+}, [fbt_sv_arg_0], {
+  hk: "3CHy8o"
+})))], {
+  hk: "2mDoBt"
+});"
+`;

--- a/packages/babel-plugin-fbtee/src/__tests__/FbtTestUtil.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/FbtTestUtil.tsx
@@ -199,7 +199,7 @@ const indent = (code: string) =>
     .map((line) => ' '.repeat(2) + line)
     .join('\n');
 
-export function assertSourceAstEqual(
+function assertSourceAstEqual(
   expected: string,
   actual: string,
   options?: Options,

--- a/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtPronoun-test.tsx.snap
+++ b/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtPronoun-test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fbt pronoun support "capitalize" option accepts boolean literal true 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: {
+      m: [null],
+      t: {
+        1: {
+          desc: "Capitalized possessive pronoun",
+          text: "Her birthday is today.",
+        },
+        2: {
+          desc: "Capitalized possessive pronoun",
+          text: "His birthday is today.",
+        },
+        "*": {
+          desc: "Capitalized possessive pronoun",
+          text: "Their birthday is today.",
+        },
+      },
+    },
+    project: "",
+  } /* __FBT__ end */,
+  [fbt._pronoun(1, gender)]
+);
+
+`;
+
+exports[`fbt pronoun support Should elide false "human" option from fbt.pronoun() 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: {
+      m: [null],
+      t: {
+        1: { desc: "Elided false option", text: "Wish her a happy birthday." },
+        2: { desc: "Elided false option", text: "Wish him a happy birthday." },
+        "*": {
+          desc: "Elided false option",
+          text: "Wish them a happy birthday.",
+        },
+      },
+    },
+    project: "",
+  } /* __FBT__ end */,
+  [
+    fbt._pronoun(0, gender, {
+      human: 1,
+    }),
+  ]
+);
+
+`;

--- a/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtStaticJSModule-test.tsx.snap
+++ b/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtStaticJSModule-test.tsx.snap
@@ -889,6 +889,50 @@ var x =
 
 `;
 
+exports[`fbt preserveWhitespace argument should coalesce whitespace in desc when not requested 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "two lines", text: "one line" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should coalesce whitespace in desc when not requested 2`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "two spaces", text: "one space" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should coalesce whitespace in text when not requested 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "one space", text: "two spaces" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should coalesce whitespace in text when not requested 2`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "one line", text: "two lines" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
 exports[`fbt preserveWhitespace argument should preserve whitespace around text with inner text and string variation 1`] = `
 var fbt_sv_arg_0;
 import { fbt } from "fbtee";
@@ -1005,5 +1049,49 @@ var x =
       ),
     ]
   ));
+
+`;
+
+exports[`fbt preserveWhitespace argument should preserve whitespace in desc when requested 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "two\\nlines", text: "one line" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should preserve whitespace in desc when requested 2`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "two  spaces", text: "one space" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should preserve whitespace in text when requested 1`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "one line", text: "two\\nlines" } },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
+exports[`fbt preserveWhitespace argument should preserve whitespace in text when requested 2`] = `
+import { fbt } from "fbtee";
+var x = fbt._(
+  /* __FBT__ start */ {
+    jsfbt: { m: [], t: { desc: "one space", text: "two  spaces" } },
+    project: "",
+  } /* __FBT__ end */
+);
 
 `;

--- a/packages/babel-plugin-fbtee/src/__tests__/fbtPronoun-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/fbtPronoun-test.tsx
@@ -1,57 +1,26 @@
-import { PluginOptions } from '@babel/core';
 import { describe, expect, it } from '@jest/globals';
 import {
-  assertSourceAstEqual,
-  payload,
+  jsCodeFbtCallSerializer,
+  snapshotTransform,
   transform,
   withFbtImportStatement,
 } from './FbtTestUtil.tsx';
 
-function runTest(
-  data: { input: string; output: string },
-  extra?: PluginOptions,
-) {
-  const expected = data.output;
-  const actual = transform(data.input, extra);
-  assertSourceAstEqual(expected, actual);
-}
+expect.addSnapshotSerializer(jsCodeFbtCallSerializer);
 
 describe('fbt pronoun support', () => {
   it('"capitalize" option accepts boolean literal true', () => {
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt(
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt(
             fbt.pronoun('possessive', gender, {capitalize: true}) +
               ' birthday is today.',
             'Capitalized possessive pronoun',
           );`,
+        ),
       ),
-
-      output: withFbtImportStatement(
-        `var x = fbt._(
-          ${payload({
-            jsfbt: {
-              m: [null],
-              t: {
-                '*': {
-                  desc: 'Capitalized possessive pronoun',
-                  text: 'Their birthday is today.',
-                },
-                1: {
-                  desc: 'Capitalized possessive pronoun',
-                  text: 'Her birthday is today.',
-                },
-                2: {
-                  desc: 'Capitalized possessive pronoun',
-                  text: 'His birthday is today.',
-                },
-              },
-            },
-          })},
-          [fbt._pronoun(1, gender)],
-        );`,
-      ),
-    });
+    ).toMatchSnapshot();
   });
 
   it('Should throw when using non-Boolean option value', () => {
@@ -101,8 +70,8 @@ describe('fbt pronoun support', () => {
   });
 
   it('Should elide false "human" option from fbt.pronoun()', () => {
-    runTest({
-      input:
+    expect(
+      snapshotTransform(
         // I.e. Wish them a happy birthday.
         withFbtImportStatement(
           `var x = fbt(
@@ -112,31 +81,7 @@ describe('fbt pronoun support', () => {
             'Elided false option',
           );`,
         ),
-
-      output: withFbtImportStatement(
-        `var x = fbt._(
-          ${payload({
-            jsfbt: {
-              m: [null],
-              t: {
-                '*': {
-                  desc: 'Elided false option',
-                  text: 'Wish them a happy birthday.',
-                },
-                1: {
-                  desc: 'Elided false option',
-                  text: 'Wish her a happy birthday.',
-                },
-                2: {
-                  desc: 'Elided false option',
-                  text: 'Wish him a happy birthday.',
-                },
-              },
-            },
-          })},
-          [fbt._pronoun(0, gender, {human: 1})],
-        );`,
       ),
-    });
+    ).toMatchSnapshot();
   });
 });

--- a/packages/babel-plugin-fbtee/src/__tests__/fbtStaticJSModule-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/fbtStaticJSModule-test.tsx
@@ -1,22 +1,9 @@
-import { PluginOptions } from '@babel/core';
 import { describe, expect, it } from '@jest/globals';
 import {
-  assertSourceAstEqual,
   jsCodeFbtCallSerializer,
-  payload,
   snapshotTransform,
-  transform,
   withFbtImportStatement,
 } from './FbtTestUtil.tsx';
-
-function runTest(
-  data: { input: string; output: string },
-  extra?: PluginOptions,
-) {
-  const expected = data.output;
-  const actual = transform(data.input, extra);
-  assertSourceAstEqual(expected, actual);
-}
 
 expect.addSnapshotSerializer(jsCodeFbtCallSerializer);
 
@@ -186,159 +173,74 @@ describe('fbt preserveWhitespace argument', () => {
   });
 
   it('should preserve whitespace in text when requested', () => {
-    runTest({
-      input: withFbtImportStatement(
-        String.raw`var x = fbt("two\nlines", "one line", {preserveWhitespace:true});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          String.raw`var x = fbt("two\nlines", "one line", {preserveWhitespace:true});`,
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(${payload({
-          jsfbt: {
-            m: [],
-            t: {
-              desc: 'one line',
-              text: 'two\nlines',
-            },
-          },
-        })})`,
-      ),
-    });
+    ).toMatchSnapshot();
 
-    runTest({
-      input: withFbtImportStatement(
-        'var x = fbt("two  spaces", "one space", {preserveWhitespace:true});',
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          'var x = fbt("two  spaces", "one space", {preserveWhitespace:true});',
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(${payload({
-          jsfbt: {
-            m: [],
-            t: {
-              desc: 'one space',
-              text: 'two  spaces',
-            },
-          },
-        })})`,
-      ),
-    });
+    ).toMatchSnapshot();
   });
 
   it('should preserve whitespace in desc when requested', () => {
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('one line', 'two\\nlines', {preserveWhitespace: true});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('one line', 'two\\nlines', {preserveWhitespace: true});`,
+        ),
       ),
+    ).toMatchSnapshot();
 
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'two\nlines',
-                  text: 'one line',
-                },
-              },
-            })},
-          );`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('one space', 'two  spaces', {preserveWhitespace: true});`,
+        ),
       ),
-    });
-
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('one space', 'two  spaces', {preserveWhitespace: true});`,
-      ),
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'two  spaces',
-                  text: 'one space',
-                },
-              },
-            })},
-          );`,
-      ),
-    });
+    ).toMatchSnapshot();
   });
 
   it('should coalesce whitespace in text when not requested', () => {
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('two  spaces', 'one space', {preserveWhitespace: false});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('two  spaces', 'one space', {preserveWhitespace: false});`,
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'one space',
-                  text: 'two spaces',
-                },
-              },
-            })},
-          );`,
-      ),
-    });
+    ).toMatchSnapshot();
 
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('two\\nlines', 'one line', {preserveWhitespace: false});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('two\\nlines', 'one line', {preserveWhitespace: false});`,
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'one line',
-                  text: 'two lines',
-                },
-              },
-            })},
-          );`,
-      ),
-    });
+    ).toMatchSnapshot();
   });
 
   it('should coalesce whitespace in desc when not requested', () => {
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('one line', 'two\\nlines', {preserveWhitespace: false});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('one line', 'two\\nlines', {preserveWhitespace: false});`,
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'two lines',
-                  text: 'one line',
-                },
-              },
-            })},
-          );`,
-      ),
-    });
+    ).toMatchSnapshot();
 
-    runTest({
-      input: withFbtImportStatement(
-        `var x = fbt('one space', 'two spaces', {preserveWhitespace: false});`,
+    expect(
+      snapshotTransform(
+        withFbtImportStatement(
+          `var x = fbt('one space', 'two spaces', {preserveWhitespace: false});`,
+        ),
       ),
-      output: withFbtImportStatement(
-        `var x = fbt._(
-            ${payload({
-              jsfbt: {
-                m: [],
-                t: {
-                  desc: 'two spaces',
-                  text: 'one space',
-                },
-              },
-            })},
-          );`,
-      ),
-    });
+    ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Replace `assertSourceAstEqual` with Jest snapshots

If we think this is a good idea I'll add more commits to this PR