### PR TITLE
Add createFixedFbt and FixedLocaleContext for locale-fixed translations

### DIFF
--- a/example/fixedLocale.html
+++ b/example/fixedLocale.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <meta charset="utf-8" />
+    <title>FixedLocaleContext Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+  <script src="/src/fixedLocale.tsx" type="module"></script>
+</html>

--- a/example/src/example/Example.tsx
+++ b/example/src/example/Example.tsx
@@ -1,6 +1,13 @@
 import { VStack } from '@nkzw/stack';
 import classNames from 'classnames';
-import { fbs, fbt, GenderConst, IntlVariations, setupFbtee } from 'fbtee';
+import {
+  fbs,
+  fbt,
+  FixedLocaleContext,
+  GenderConst,
+  IntlVariations,
+  setupFbtee,
+} from 'fbtee';
 import { ChangeEvent, useCallback, useState } from 'react';
 import ar_AR from '../translatedFbts/ar_AR.json' with { type: 'json' };
 import de_DE from '../translatedFbts/de_DE.json' with { type: 'json' };
@@ -35,6 +42,12 @@ setupFbtee({
   },
   translations,
 });
+
+const previewLocales = ['de_DE', 'fr_FR', 'ja_JP', 'es_LA'] as const;
+
+function LocalePreviewItem() {
+  return <fbt desc="header">Sentence Examples</fbt>;
+}
 
 type SharedObj = keyof typeof ExampleEnum;
 
@@ -282,6 +295,32 @@ export default function Example() {
                 />?
               </fbt>
             </label>
+          </fieldset>
+          <fieldset style={{ marginLeft: '0.5em' }}>
+            <h2>
+              <fbt desc="fixed locale section header">Multi-Locale Preview</fbt>
+            </h2>
+            <div
+              style={{
+                display: 'grid',
+                gap: '4px 12px',
+                gridTemplateColumns: 'auto 1fr',
+              }}
+            >
+              {previewLocales.map((previewLocale) => (
+                <>
+                  <b key={`${previewLocale}-label`}>
+                    {Locales[previewLocale].displayName}
+                  </b>
+                  <FixedLocaleContext
+                    key={previewLocale}
+                    locale={previewLocale}
+                  >
+                    <LocalePreviewItem />
+                  </FixedLocaleContext>
+                </>
+              ))}
+            </div>
           </fieldset>
           <fieldset>
             <span className="example_row">

--- a/example/src/example/FixedLocaleDemo.tsx
+++ b/example/src/example/FixedLocaleDemo.tsx
@@ -1,0 +1,263 @@
+/// <reference types="fbtee/ReactTypes" />
+/* eslint-disable @nkzw/fbtee/no-untranslated-strings */
+
+import { VStack } from '@nkzw/stack';
+import { fbs, fbt, FixedLocaleContext, setupLocaleContext } from 'fbtee';
+import { Suspense } from 'react';
+import Locales from './Locales.tsx';
+
+// Set up with ONLY en_US pre-loaded.
+// All other locales will be loaded on demand by FixedLocaleContext
+// using the registered loadLocale hook.
+setupLocaleContext({
+  availableLanguages: new Map(
+    Object.keys(Locales).map(
+      (locale) =>
+        [locale, Locales[locale as keyof typeof Locales].displayName] as const,
+    ),
+  ),
+  clientLocales: ['en_US'],
+  loadLocale: async (locale: string) => {
+    // Simulate network delay to make Suspense visible
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const mod = await import(`../translatedFbts/${locale}.json`);
+    return mod.default[locale];
+  },
+});
+
+// ============================================================
+// Child components — standard <fbt>/<fbs>, no special imports
+// ============================================================
+
+function SimpleString() {
+  return (
+    <span>
+      <fbt desc="header">Sentence Examples</fbt>
+    </span>
+  );
+}
+
+function FbsString() {
+  return <span>{fbs('Sentence Examples', 'header')}</span>;
+}
+
+function FbtFunctionalCall() {
+  const text = fbt('Sentence Examples', 'header');
+  return <span>{text}</span>;
+}
+
+function MixedFbtAndFbs() {
+  const label = fbs('Sentence Examples', 'header');
+  return (
+    <span>
+      {label}
+      {' — '}
+      <fbt desc="header">Sentence Examples</fbt>
+    </span>
+  );
+}
+
+// ============================================================
+// Test case display
+// ============================================================
+
+function TestCase({
+  children,
+  expect: expected,
+  title,
+}: {
+  children: React.ReactNode;
+  expect: string;
+  title: string;
+}) {
+  return (
+    <div style={{ borderBottom: '1px solid #ddd', padding: '12px 0' }}>
+      <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>{title}</div>
+      <div
+        style={{
+          display: 'grid',
+          gap: '4px 16px',
+          gridTemplateColumns: 'auto 1fr',
+        }}
+      >
+        <span style={{ color: '#888' }}>Expected:</span>
+        <span>{expected}</span>
+        <span style={{ color: '#888' }}>Got:</span>
+        <span style={{ background: '#f0f0ff', padding: '2px 6px' }}>
+          {children}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// Main demo
+// ============================================================
+
+export default function FixedLocaleDemo() {
+  return (
+    <div
+      className="example"
+      style={{ margin: '20px auto', maxWidth: 700, width: '100%' }}
+    >
+      <div className="headline">
+        <b>FixedLocaleContext</b> Demo
+      </div>
+
+      <VStack gap>
+        <p style={{ color: '#666' }}>
+          Only en_US is pre-loaded. All other locales are loaded on demand (with
+          a 1s simulated delay). Watch for the &quot;Loading...&quot; fallback
+          from Suspense.
+        </p>
+
+        <h2>Basic: fbt JSX in child component</h2>
+
+        <TestCase
+          expect="Beispielsätze"
+          title="<fbt> inside FixedLocaleContext (de_DE) — loaded on demand"
+        >
+          <Suspense fallback={<em>Loading de_DE...</em>}>
+            <FixedLocaleContext locale="de_DE">
+              <SimpleString />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <TestCase
+          expect="Exemples de phrases"
+          title="<fbt> inside FixedLocaleContext (fr_FR) — loaded on demand"
+        >
+          <Suspense fallback={<em>Loading fr_FR...</em>}>
+            <FixedLocaleContext locale="fr_FR">
+              <SimpleString />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <TestCase
+          expect="文例"
+          title="<fbt> inside FixedLocaleContext (ja_JP) — loaded on demand"
+        >
+          <Suspense fallback={<em>Loading ja_JP...</em>}>
+            <FixedLocaleContext locale="ja_JP">
+              <SimpleString />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <TestCase
+          expect="Sentence Examples"
+          title="<fbt> WITHOUT FixedLocaleContext (global en_US)"
+        >
+          <SimpleString />
+        </TestCase>
+
+        <h2>fbs() support</h2>
+
+        <TestCase
+          expect="Beispielsätze"
+          title="fbs() inside FixedLocaleContext (de_DE)"
+        >
+          <Suspense fallback={<em>Loading...</em>}>
+            <FixedLocaleContext locale="de_DE">
+              <FbsString />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <h2>Functional fbt() call</h2>
+
+        <TestCase
+          expect="Beispielsätze"
+          title="fbt() functional call inside FixedLocaleContext (de_DE)"
+        >
+          <Suspense fallback={<em>Loading...</em>}>
+            <FixedLocaleContext locale="de_DE">
+              <FbtFunctionalCall />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <h2>Mixed fbt + fbs in same component</h2>
+
+        <TestCase
+          expect="Beispielsätze — Beispielsätze"
+          title="Mixed fbs() + <fbt> in same component (de_DE)"
+        >
+          <Suspense fallback={<em>Loading...</em>}>
+            <FixedLocaleContext locale="de_DE">
+              <MixedFbtAndFbs />
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <h2>Nested contexts</h2>
+
+        <TestCase
+          expect="Exemples de phrases"
+          title="Inner FixedLocaleContext (fr_FR) overrides outer (de_DE)"
+        >
+          <Suspense fallback={<em>Loading...</em>}>
+            <FixedLocaleContext locale="de_DE">
+              <FixedLocaleContext locale="fr_FR">
+                <SimpleString />
+              </FixedLocaleContext>
+            </FixedLocaleContext>
+          </Suspense>
+        </TestCase>
+
+        <TestCase
+          expect="Beispielsätze | Exemples de phrases"
+          title="Sibling FixedLocaleContexts are independent"
+        >
+          <Suspense fallback={<em>Loading...</em>}>
+            <span style={{ display: 'flex', gap: 8 }}>
+              <FixedLocaleContext locale="de_DE">
+                <SimpleString />
+              </FixedLocaleContext>
+              {' | '}
+              <FixedLocaleContext locale="fr_FR">
+                <SimpleString />
+              </FixedLocaleContext>
+            </span>
+          </Suspense>
+        </TestCase>
+
+        <h2>All available locales (all loaded on demand)</h2>
+
+        <Suspense fallback={<em>Loading all locales...</em>}>
+          <div
+            style={{
+              display: 'grid',
+              gap: '4px 16px',
+              gridTemplateColumns: 'auto 1fr',
+            }}
+          >
+            {(
+              [
+                'en_US',
+                'de_DE',
+                'fr_FR',
+                'es_LA',
+                'ja_JP',
+                'ar_AR',
+                'he_IL',
+                'it_IT',
+                'fb_HX',
+              ] as const
+            ).map((loc) => (
+              <div key={loc} style={{ display: 'contents' }}>
+                <b>{loc}</b>
+                <FixedLocaleContext locale={loc}>
+                  <SimpleString />
+                </FixedLocaleContext>
+              </div>
+            ))}
+          </div>
+        </Suspense>
+      </VStack>
+    </div>
+  );
+}

--- a/example/src/example/__tests__/__snapshots__/Example-test.tsx.snap
+++ b/example/src/example/__tests__/__snapshots__/Example-test.tsx.snap
@@ -247,6 +247,33 @@ exports[`Example.react renders the example 1`] = `
             Do you want to share a photo, a link or a video?
           </label>
         </fieldset>
+        <fieldset
+          style="margin-left: 0.5em;"
+        >
+          <h2>
+            Multi-Locale Preview
+          </h2>
+          <div
+            style="display: grid; gap: 4px 12px; grid-template-columns: auto 1fr;"
+          >
+            <b>
+              Deutsch
+            </b>
+            Beispielsätze
+            <b>
+              Français
+            </b>
+            Exemples de phrases
+            <b>
+              日本語
+            </b>
+            文例
+            <b>
+              Español
+            </b>
+            Ejemplos de oraciones
+          </div>
+        </fieldset>
         <fieldset>
           <span
             class="example_row"

--- a/example/src/fixedLocale.tsx
+++ b/example/src/fixedLocale.tsx
@@ -1,0 +1,11 @@
+import 'normalize.css';
+import './root.css';
+import './example/Example.css';
+import { createRoot } from 'react-dom/client';
+import FixedLocaleDemo from './example/FixedLocaleDemo.tsx';
+
+const root = document.getElementById('root')!;
+root.style.justifyContent = 'flex-start';
+root.style.height = 'auto';
+root.style.minHeight = '100%';
+createRoot(root).render(<FixedLocaleDemo />);

--- a/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtLocaleOverride-test.tsx.snap
+++ b/packages/babel-plugin-fbtee/src/__tests__/__snapshots__/fbtLocaleOverride-test.tsx.snap
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`FixedLocaleContext: babel plugin locale override injection component detection (name starts with uppercase) should inject __fbtLocaleOverride in a function expression component 1`] = `
+import { fbt } from "fbtee";
+const MyComponent = function () {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+};
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection component detection (name starts with uppercase) should inject __fbtLocaleOverride in a named function component 1`] = `
+import { fbt } from "fbtee";
+function MyComponent() {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection component detection (name starts with uppercase) should inject __fbtLocaleOverride in an arrow function component 1`] = `
+import { fbt } from "fbtee";
+const MyComponent = () => {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+};
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection fbs support should inject __fbtLocaleOverride for fbs calls in a component 1`] = `
+import { fbs } from "fbtee";
+function MyComponent() {
+  const __fbtLocaleOverride = fbs.__locale?.() ?? null;
+  return fbs._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection fbs support should inject once for mixed fbt and fbs calls 1`] = `
+import { fbt, fbs } from "fbtee";
+function MyComponent() {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  const label = fbs._(
+    "label",
+    null,
+    {
+      hk: "OoWAh",
+    },
+    __fbtLocaleOverride
+  );
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection forwardRef and memo should inject in React.forwardRef callback 1`] = `
+import { fbt } from "fbtee";
+import React from "react";
+const MyComponent = /*#__PURE__*/ React.forwardRef(function (props, ref) {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+});
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection forwardRef and memo should inject in React.memo callback 1`] = `
+import { fbt } from "fbtee";
+import React from "react";
+const MyComponent = /*#__PURE__*/ React.memo(function () {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+});
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection fourth argument passing should pass __fbtLocaleOverride as 4th argument to fbt._ calls 1`] = `
+import { fbt } from "fbtee";
+function MyComponent() {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello World",
+    null,
+    {
+      hk: "RdrwZ",
+    },
+    __fbtLocaleOverride
+  );
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection fourth argument passing should pass __fbtLocaleOverride to all fbt._ calls in a component 1`] = `
+import { fbt } from "fbtee";
+function MyComponent() {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  const a = fbt._(
+    "First",
+    null,
+    {
+      hk: "1Ir5zc",
+    },
+    __fbtLocaleOverride
+  );
+  const b = fbt._(
+    "Second",
+    null,
+    {
+      hk: "3U4k6O",
+    },
+    __fbtLocaleOverride
+  );
+  return a + b;
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection hook detection (name starts with use) should inject __fbtLocaleOverride in a custom hook 1`] = `
+import { fbt } from "fbtee";
+function useGreeting() {
+  const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+  return fbt._(
+    "Hello",
+    null,
+    {
+      hk: "1d8blU",
+    },
+    __fbtLocaleOverride
+  );
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection no fbt calls should NOT inject when function has no fbt calls 1`] = `
+import { fbt } from "fbtee";
+function MyComponent() {
+  return "no fbt here";
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection non-component functions should NOT inject __fbtLocaleOverride in a regular function 1`] = `
+import { fbt } from "fbtee";
+function formatMessage() {
+  return fbt._("Hello", null, {
+    hk: "1d8blU",
+  });
+}
+
+`;
+
+exports[`FixedLocaleContext: babel plugin locale override injection non-component functions should NOT inject __fbtLocaleOverride in a top-level fbt call 1`] = `
+import { fbt } from "fbtee";
+const greeting = fbt._("Hello", null, {
+  hk: "1d8blU",
+});
+
+`;

--- a/packages/babel-plugin-fbtee/src/__tests__/fbtLocaleOverride-test.tsx
+++ b/packages/babel-plugin-fbtee/src/__tests__/fbtLocaleOverride-test.tsx
@@ -1,0 +1,181 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  jsCodeFbtCallSerializer,
+  snapshotTransform,
+  withFbtImportStatement,
+} from './FbtTestUtil.tsx';
+
+expect.addSnapshotSerializer(jsCodeFbtCallSerializer);
+
+describe('FixedLocaleContext: babel plugin locale override injection', () => {
+  describe('component detection (name starts with uppercase)', () => {
+    it('should inject __fbtLocaleOverride in a named function component', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function MyComponent() {
+              return fbt("Hello", "greeting");
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should inject __fbtLocaleOverride in an arrow function component', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            const MyComponent = () => {
+              return fbt("Hello", "greeting");
+            };
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should inject __fbtLocaleOverride in a function expression component', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            const MyComponent = function() {
+              return fbt("Hello", "greeting");
+            };
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('hook detection (name starts with use)', () => {
+    it('should inject __fbtLocaleOverride in a custom hook', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function useGreeting() {
+              return fbt("Hello", "greeting");
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('non-component functions', () => {
+    it('should NOT inject __fbtLocaleOverride in a regular function', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function formatMessage() {
+              return fbt("Hello", "greeting");
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should NOT inject __fbtLocaleOverride in a top-level fbt call', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            const greeting = fbt("Hello", "greeting");
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('fbs support', () => {
+    it('should inject __fbtLocaleOverride for fbs calls in a component', () => {
+      expect(
+        snapshotTransform(`
+          import { fbs } from "fbtee";
+          function MyComponent() {
+            return fbs("Hello", "greeting");
+          }
+        `),
+      ).toMatchSnapshot();
+    });
+
+    it('should inject once for mixed fbt and fbs calls', () => {
+      expect(
+        snapshotTransform(`
+          import { fbt, fbs } from "fbtee";
+          function MyComponent() {
+            const label = fbs("label", "desc");
+            return fbt("Hello", "greeting");
+          }
+        `),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('forwardRef and memo', () => {
+    it('should inject in React.forwardRef callback', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            import React from "react";
+            const MyComponent = React.forwardRef(function(props, ref) {
+              return fbt("Hello", "greeting");
+            });
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should inject in React.memo callback', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            import React from "react";
+            const MyComponent = React.memo(function() {
+              return fbt("Hello", "greeting");
+            });
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('fourth argument passing', () => {
+    it('should pass __fbtLocaleOverride as 4th argument to fbt._ calls', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function MyComponent() {
+              return <fbt desc="greeting">Hello World</fbt>;
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('should pass __fbtLocaleOverride to all fbt._ calls in a component', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function MyComponent() {
+              const a = fbt("First", "desc1");
+              const b = fbt("Second", "desc2");
+              return a + b;
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('no fbt calls', () => {
+    it('should NOT inject when function has no fbt calls', () => {
+      expect(
+        snapshotTransform(
+          withFbtImportStatement(`
+            function MyComponent() {
+              return "no fbt here";
+            }
+          `),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/babel-plugin-fbtee/src/index.tsx
+++ b/packages/babel-plugin-fbtee/src/index.tsx
@@ -1,9 +1,23 @@
 import type { NodePath } from '@babel/core';
 import {
   CallExpression,
+  identifier,
   ImportDeclaration,
+  isArrowFunctionExpression,
+  isCallExpression,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isMemberExpression,
+  isVariableDeclarator,
   JSXElement,
+  logicalExpression,
   Node,
+  nullLiteral,
+  optionalCallExpression,
+  optionalMemberExpression,
+  variableDeclaration,
+  variableDeclarator,
 } from '@babel/types';
 import { parse as parseDocblock } from 'jest-docblock';
 import FbtCommonFunctionCallProcessor from './babel-processors/FbtCommonFunctionCallProcessor.tsx';
@@ -16,7 +30,11 @@ import { toPlainFbtNodeTree } from './fbt-nodes/FbtNodeUtil.tsx';
 import type { FbtCommonMap } from './FbtCommon.tsx';
 import { init } from './FbtCommon.tsx';
 import type { FbtCallSiteOptions, FbtOptionConfig } from './FbtConstants.tsx';
-import { ValidFbtOptions } from './FbtConstants.tsx';
+import {
+  FbsBindingName,
+  FbtBindingName,
+  ValidFbtOptions,
+} from './FbtConstants.tsx';
 import type { EnumManifest } from './FbtEnumRegistrar.tsx';
 import FbtEnumRegistrar from './FbtEnumRegistrar.tsx';
 import FbtNodeChecker from './FbtNodeChecker.tsx';
@@ -192,6 +210,206 @@ type Visitor = {
 
 const toVisitor = (visitor: unknown): visitor is Visitor => true;
 
+const LOCALE_OVERRIDE_VAR = '__fbtLocaleOverride';
+
+/**
+ * Check if a name looks like a React component (starts with uppercase)
+ * or a custom hook (starts with "use" followed by uppercase).
+ */
+function isComponentishName(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+function isHookName(name: string): boolean {
+  return /^use[\dA-Z]/.test(name) || name === 'use';
+}
+
+/**
+ * Get the inferred name of a function from its declaration or assignment context.
+ */
+function getFunctionName(path: NodePath): string | null {
+  const node = path.node;
+  if (isFunctionDeclaration(node) && node.id) {
+    return node.id.name;
+  }
+  if (
+    (isFunctionExpression(node) || isArrowFunctionExpression(node)) &&
+    path.parentPath &&
+    isVariableDeclarator(path.parent) &&
+    isIdentifier(path.parent.id)
+  ) {
+    return path.parent.id.name;
+  }
+  return null;
+}
+
+/**
+ * Check if a function is a callback passed to React.forwardRef() or React.memo().
+ */
+function isForwardRefOrMemoCallback(path: NodePath): boolean {
+  const parent = path.parentPath;
+  if (!parent || !isCallExpression(parent.node)) {
+    return false;
+  }
+  const callee = parent.node.callee;
+  if (
+    isMemberExpression(callee) &&
+    isIdentifier(callee.object) &&
+    callee.object.name === 'React' &&
+    isIdentifier(callee.property) &&
+    (callee.property.name === 'forwardRef' || callee.property.name === 'memo')
+  ) {
+    return true;
+  }
+  if (
+    isIdentifier(callee) &&
+    (callee.name === 'forwardRef' || callee.name === 'memo')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Determine if a function should receive the locale override injection.
+ */
+function shouldInjectLocaleOverride(path: NodePath): boolean {
+  const name = getFunctionName(path);
+  if (name && (isComponentishName(name) || isHookName(name))) {
+    return true;
+  }
+  return isForwardRefOrMemoCallback(path);
+}
+
+/**
+ * Check if a call expression is an fbt._() or fbs._() call.
+ */
+function isFbtRuntimeCall(node: Node): boolean {
+  return (
+    isCallExpression(node) &&
+    isMemberExpression(node.callee) &&
+    isIdentifier(node.callee.object) &&
+    (node.callee.object.name === FbtBindingName ||
+      node.callee.object.name === FbsBindingName) &&
+    isIdentifier(node.callee.property) &&
+    node.callee.property.name === '_'
+  );
+}
+
+/**
+ * Find which fbt/fbs module name is in scope for a function path.
+ */
+function getFbtModuleInScope(path: NodePath): string | null {
+  const scope = path.scope;
+  if (scope.getBinding(FbtBindingName)) {
+    return FbtBindingName;
+  }
+  if (scope.getBinding(FbsBindingName)) {
+    return FbsBindingName;
+  }
+  return null;
+}
+
+/**
+ * Inject locale override into qualifying functions in the Program.exit phase.
+ *
+ * For React components and hooks that contain fbt._() or fbs._() calls:
+ * 1. Inject `const __fbtLocaleOverride = fbt.__locale?.() ?? null;` at the top
+ * 2. Add `__fbtLocaleOverride` as the 4th argument to all fbt._() / fbs._() calls
+ */
+function injectLocaleOverrides(programPath: NodePath<Node>): void {
+  const functionPaths: Array<NodePath> = [];
+
+  // Collect all function paths that should receive injection
+  programPath.traverse({
+    ArrowFunctionExpression(path: NodePath) {
+      if (shouldInjectLocaleOverride(path)) {
+        functionPaths.push(path);
+      }
+    },
+    FunctionDeclaration(path: NodePath) {
+      if (shouldInjectLocaleOverride(path)) {
+        functionPaths.push(path);
+      }
+    },
+    FunctionExpression(path: NodePath) {
+      if (shouldInjectLocaleOverride(path)) {
+        functionPaths.push(path);
+      }
+    },
+  });
+
+  for (const fnPath of functionPaths) {
+    const fbtModule = getFbtModuleInScope(fnPath);
+    if (!fbtModule) {
+      continue;
+    }
+
+    // Find all fbt._() / fbs._() calls in this function (not nested functions)
+    const fbtCalls: Array<NodePath<CallExpression>> = [];
+
+    fnPath.traverse({
+      ArrowFunctionExpression(path: NodePath) {
+        path.skip(); // Don't descend into nested functions
+      },
+      CallExpression(path: NodePath<CallExpression>) {
+        if (isFbtRuntimeCall(path.node)) {
+          fbtCalls.push(path);
+        }
+      },
+      FunctionDeclaration(path: NodePath) {
+        path.skip();
+      },
+      FunctionExpression(path: NodePath) {
+        path.skip();
+      },
+    });
+
+    if (fbtCalls.length === 0) {
+      continue;
+    }
+
+    // 1. Inject: const __fbtLocaleOverride = fbt.__locale?.() ?? null;
+    // Generate: fbt.__locale?.() ?? null
+    const localeCallExpr = logicalExpression(
+      '??',
+      optionalCallExpression(
+        optionalMemberExpression(
+          identifier(fbtModule),
+          identifier('__locale'),
+          false,
+          false, // not optional at this level (fbt.__locale)
+        ),
+        [],
+        true, // optional call: ?.()
+      ),
+      nullLiteral(),
+    );
+
+    const declaration = variableDeclaration('const', [
+      variableDeclarator(identifier(LOCALE_OVERRIDE_VAR), localeCallExpr),
+    ]);
+
+    // Get the function body
+    const body = fnPath.get('body') as NodePath;
+    if (body.isBlockStatement()) {
+      (
+        body as NodePath<import('@babel/types').BlockStatement>
+      ).unshiftContainer('body', declaration);
+    }
+
+    // 2. Add __fbtLocaleOverride as 4th argument to all fbt._() calls
+    for (const callPath of fbtCalls) {
+      const args = callPath.node.arguments;
+      // Ensure we have at least 3 arguments (table, args, opts)
+      while (args.length < 3) {
+        args.push(nullLiteral());
+      }
+      args.push(identifier(LOCALE_OVERRIDE_VAR));
+    }
+  }
+}
+
 export default function transform() {
   return {
     name: 'fbtee',
@@ -305,6 +523,8 @@ export default function transform() {
               }
             },
           });
+
+          injectLocaleOverrides(path);
         },
       },
     },

--- a/packages/fbtee/src/FixedLocaleContext.tsx
+++ b/packages/fbtee/src/FixedLocaleContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, ReactNode, use, useMemo } from 'react';
+import createFixedFbt from './createFixedFbt.tsx';
+import type { FbtLocaleOverride } from './fbt.tsx';
+import { setLocaleOverrideHook } from './Hooks.tsx';
+import type { Gender } from './setupLocaleContext.tsx';
+
+const FbtLocaleOverrideContext = createContext<FbtLocaleOverride>(null);
+
+setLocaleOverrideHook(() => use(FbtLocaleOverrideContext));
+
+/**
+ * Provides a fixed locale for all `<fbt>`, `fbt()`, `<fbs>`, and `fbs()` calls
+ * in descendant components. The override is transparent — child components
+ * require no special imports or call-site changes.
+ *
+ * Note: Like all React context providers, this only affects **child components**,
+ * not `fbt`/`fbs` calls in the same component that renders `<FixedLocaleContext>`.
+ * Translated content must be in a separate child component:
+ *
+ * ```tsx
+ * // ✓ Correct — child component renders inside the provider
+ * <FixedLocaleContext locale="de_DE">
+ *   <MyTranslatedComponent />
+ * </FixedLocaleContext>
+ *
+ * // ✗ Won't work — fbt call is evaluated in the parent's render
+ * <FixedLocaleContext locale="de_DE">
+ *   <fbt desc="greeting">Hello</fbt>
+ * </FixedLocaleContext>
+ * ```
+ */
+export default function FixedLocaleContext({
+  children,
+  gender,
+  locale,
+}: {
+  children: ReactNode;
+  gender?: Gender;
+  locale: string;
+}) {
+  const override = useMemo(
+    () => createFixedFbt(locale, gender),
+    [gender, locale],
+  );
+  return (
+    <FbtLocaleOverrideContext value={override}>
+      {children}
+    </FbtLocaleOverrideContext>
+  );
+}

--- a/packages/fbtee/src/FixedLocaleContext.tsx
+++ b/packages/fbtee/src/FixedLocaleContext.tsx
@@ -1,17 +1,46 @@
 import { createContext, ReactNode, use, useMemo } from 'react';
 import createFixedFbt from './createFixedFbt.tsx';
 import type { FbtLocaleOverride } from './fbt.tsx';
-import { setLocaleOverrideHook } from './Hooks.tsx';
+import FbtTranslations from './FbtTranslations.tsx';
+import Hooks, { setLocaleOverrideHook } from './Hooks.tsx';
 import type { Gender } from './setupLocaleContext.tsx';
 
 const FbtLocaleOverrideContext = createContext<FbtLocaleOverride>(null);
 
 setLocaleOverrideHook(() => use(FbtLocaleOverrideContext));
 
+const localeLoadPromises = new Map<string, Promise<void>>();
+
+function useEnsureLocaleLoaded(locale: string): void {
+  const translations = FbtTranslations.getRegisteredTranslations();
+  if (translations[locale]) {
+    return;
+  }
+
+  const loadLocale = Hooks.getLoadLocale();
+  if (!loadLocale) {
+    return;
+  }
+
+  let promise = localeLoadPromises.get(locale);
+  if (!promise) {
+    promise = loadLocale(locale).then((result) => {
+      FbtTranslations.mergeTranslations({ [locale]: result });
+    });
+    localeLoadPromises.set(locale, promise);
+  }
+
+  use(promise);
+}
+
 /**
  * Provides a fixed locale for all `<fbt>`, `fbt()`, `<fbs>`, and `fbs()` calls
  * in descendant components. The override is transparent — child components
  * require no special imports or call-site changes.
+ *
+ * If translations for the requested locale are not yet loaded and a `loadLocale`
+ * hook has been registered (via `setupLocaleContext`), the component will suspend
+ * until translations are available. Wrap in `<Suspense>` to handle the loading state.
  *
  * Note: Like all React context providers, this only affects **child components**,
  * not `fbt`/`fbs` calls in the same component that renders `<FixedLocaleContext>`.
@@ -38,6 +67,8 @@ export default function FixedLocaleContext({
   gender?: Gender;
   locale: string;
 }) {
+  useEnsureLocaleLoaded(locale);
+
   const override = useMemo(
     () => createFixedFbt(locale, gender),
     [gender, locale],

--- a/packages/fbtee/src/Hooks.tsx
+++ b/packages/fbtee/src/Hooks.tsx
@@ -94,6 +94,16 @@ export type Hooks = Partial<{
 
 const _registrations: Hooks = {};
 
+let _localeOverrideHook: (() => unknown) | null = null;
+
+export function getLocaleOverrideHook(): (() => unknown) | null {
+  return _localeOverrideHook;
+}
+
+export function setLocaleOverrideHook(hook: () => unknown): void {
+  _localeOverrideHook = hook;
+}
+
 export default {
   getErrorListener(context: FbtErrorContext): IFbtErrorListener | null {
     return _registrations.errorListener?.(context) || null;

--- a/packages/fbtee/src/Hooks.tsx
+++ b/packages/fbtee/src/Hooks.tsx
@@ -84,12 +84,17 @@ export type FbtImpressionOptions = {
   tokens: Array<FbtTableKey>;
 };
 
+export type LoadLocaleFn = (
+  locale: string,
+) => Promise<{ [hashKey: string]: FbtRuntimeInput }>;
+
 export type Hooks = Partial<{
   errorListener: (context: FbtErrorContext) => IFbtErrorListener | null;
   getFbsResult: ResolverFn<PlainStringResult>;
   getFbtResult: ResolverFn<FbtResult>;
   getTranslatedInput: (input: FbtRuntimeCallInput) => FbtTranslatedInput | null;
   getViewerContext: () => typeof IntlViewerContext;
+  loadLocale: LoadLocaleFn;
 }>;
 
 const _registrations: Hooks = {};
@@ -131,6 +136,10 @@ export default {
       throw new Error(`Hooks: 'getFbtResult' is not registered`);
     }
     return getFbtResult(contents, hashKey, errorListener);
+  },
+
+  getLoadLocale(): LoadLocaleFn | null {
+    return _registrations.loadLocale ?? null;
   },
 
   getTranslatedInput(input: FbtRuntimeCallInput): FbtTranslatedInput {

--- a/packages/fbtee/src/__tests__/FixedLocaleContext-test.tsx
+++ b/packages/fbtee/src/__tests__/FixedLocaleContext-test.tsx
@@ -1,0 +1,132 @@
+/// <reference types="../../ReactTypes.d.ts" />
+
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react';
+import fbsInternal from '../fbs.tsx';
+import fbtInternal from '../fbt.tsx';
+import FixedLocaleContext from '../FixedLocaleContext.tsx';
+import Hooks from '../Hooks.tsx';
+import { setupFbtee } from '../index.tsx';
+import IntlViewerContext from '../ViewerContext.tsx';
+
+setupFbtee({
+  hooks: {
+    getViewerContext: () => IntlViewerContext,
+  },
+  translations: {
+    de_DE: {
+      hash1: 'Hallo Welt',
+      hash2: 'Beispielsätze',
+    },
+    en_US: {},
+    fr_FR: {
+      hash1: 'Bonjour le monde',
+      hash2: 'Exemples de phrases',
+    },
+  },
+});
+
+function HelloWorld() {
+  // Simulates what the babel plugin generates:
+  // 1. Call fbt.__locale() to get the override from context
+  // 2. Pass it as 4th arg to fbt._()
+  const __fbtLocaleOverride = fbtInternal.__locale?.() ?? null;
+  return (
+    <span>
+      {fbtInternal
+        ._(['Hello World', 'hash1'], null, { hk: 'hash1' }, __fbtLocaleOverride)
+        .toString()}
+    </span>
+  );
+}
+
+function SentenceExamples() {
+  const __fbtLocaleOverride = fbtInternal.__locale?.() ?? null;
+  return (
+    <span>
+      {fbtInternal
+        ._(
+          ['Sentence Examples', 'hash2'],
+          null,
+          { hk: 'hash2' },
+          __fbtLocaleOverride,
+        )
+        .toString()}
+    </span>
+  );
+}
+
+describe('FixedLocaleContext', () => {
+  it('should render children in the fixed locale', () => {
+    const { container } = render(
+      <FixedLocaleContext locale="de_DE">
+        <HelloWorld />
+      </FixedLocaleContext>,
+    );
+    expect(container.textContent).toBe('Hallo Welt');
+  });
+
+  it('should not affect components outside the context', () => {
+    const { container } = render(
+      <div>
+        <HelloWorld />
+        <FixedLocaleContext locale="de_DE">
+          <SentenceExamples />
+        </FixedLocaleContext>
+      </div>,
+    );
+    const spans = container.querySelectorAll('span');
+    expect(spans[0].textContent).toBe('Hello World');
+    expect(spans[1].textContent).toBe('Beispielsätze');
+  });
+
+  it('should support nested contexts (inner overrides outer)', () => {
+    const { container } = render(
+      <FixedLocaleContext locale="de_DE">
+        <div>
+          <HelloWorld />
+          <FixedLocaleContext locale="fr_FR">
+            <SentenceExamples />
+          </FixedLocaleContext>
+        </div>
+      </FixedLocaleContext>,
+    );
+    const spans = container.querySelectorAll('span');
+    expect(spans[0].textContent).toBe('Hallo Welt');
+    expect(spans[1].textContent).toBe('Exemples de phrases');
+  });
+
+  it('should not affect the global viewer context', () => {
+    render(
+      <FixedLocaleContext locale="de_DE">
+        <HelloWorld />
+      </FixedLocaleContext>,
+    );
+    expect(Hooks.getViewerContext().locale).toBe('en_US');
+  });
+
+  it('should work with fbs calls', () => {
+    function FbsComponent() {
+      const __fbtLocaleOverride = fbsInternal.__locale?.() ?? null;
+      return (
+        <span>
+          {fbsInternal
+            ._(
+              ['Hello World', 'hash1'],
+              null,
+              { hk: 'hash1' },
+              __fbtLocaleOverride,
+            )
+            .toString()}
+        </span>
+      );
+    }
+
+    const { container } = render(
+      <FixedLocaleContext locale="de_DE">
+        <FbsComponent />
+      </FixedLocaleContext>,
+    );
+    expect(container.textContent).toBe('Hallo Welt');
+  });
+});

--- a/packages/fbtee/src/__tests__/FixedLocaleContext-test.tsx
+++ b/packages/fbtee/src/__tests__/FixedLocaleContext-test.tsx
@@ -1,9 +1,11 @@
 /// <reference types="../../ReactTypes.d.ts" />
 
 import { describe, expect, it } from '@jest/globals';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
+import { Suspense } from 'react';
 import fbsInternal from '../fbs.tsx';
 import fbtInternal from '../fbt.tsx';
+import FbtTranslations from '../FbtTranslations.tsx';
 import FixedLocaleContext from '../FixedLocaleContext.tsx';
 import Hooks from '../Hooks.tsx';
 import { setupFbtee } from '../index.tsx';
@@ -103,6 +105,55 @@ describe('FixedLocaleContext', () => {
       </FixedLocaleContext>,
     );
     expect(Hooks.getViewerContext().locale).toBe('en_US');
+  });
+
+  it('should load translations on demand via registered loadLocale', async () => {
+    // Register a loadLocale hook
+    Hooks.register({
+      loadLocale: (locale) => {
+        if (locale === 'pt_PT') {
+          return Promise.resolve({ hash1: 'Olá Mundo' });
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    // Verify pt_PT is not yet loaded
+    expect(
+      FbtTranslations.getRegisteredTranslations()['pt_PT'],
+    ).toBeUndefined();
+
+    function PtHelloWorld() {
+      const __fbtLocaleOverride = fbtInternal.__locale?.() ?? null;
+      return (
+        <span>
+          {fbtInternal
+            ._(
+              ['Hello World', 'hash1'],
+              null,
+              { hk: 'hash1' },
+              __fbtLocaleOverride,
+            )
+            .toString()}
+        </span>
+      );
+    }
+
+    const { container } = await act(() =>
+      render(
+        <Suspense fallback={<span>{'Loading...'}</span>}>
+          <FixedLocaleContext locale="pt_PT">
+            <PtHelloWorld />
+          </FixedLocaleContext>
+        </Suspense>,
+      ),
+    );
+
+    expect(container.textContent).toBe('Olá Mundo');
+    // Translations should now be merged into the global dictionary
+    expect(FbtTranslations.getRegisteredTranslations()['pt_PT']).toEqual({
+      hash1: 'Olá Mundo',
+    });
   });
 
   it('should work with fbs calls', () => {

--- a/packages/fbtee/src/__tests__/createFixedFbt-test.tsx
+++ b/packages/fbtee/src/__tests__/createFixedFbt-test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it } from '@jest/globals';
+import createFixedFbt from '../createFixedFbt.tsx';
+import FbtTranslations from '../FbtTranslations.tsx';
+import Hooks from '../Hooks.tsx';
+import setupFbtee from '../setupFbtee.tsx';
+import IntlViewerContext from '../ViewerContext.tsx';
+
+setupFbtee({
+  hooks: {
+    getViewerContext: () => IntlViewerContext,
+  },
+  translations: {
+    de_DE: {
+      hash1: 'Hallo {name}',
+      hash2: 'Einfacher Text',
+      hash3: {
+        '*': '{name} hat {count} Sachen',
+      },
+    },
+    en_US: {},
+    fr_FR: {
+      hash1: 'Bonjour {name}',
+      hash2: 'Texte simple',
+    },
+  },
+});
+
+describe('createFixedFbt', () => {
+  it('should translate using the fixed locale', () => {
+    const { fbt } = createFixedFbt('de_DE');
+    expect(
+      fbt
+        ._(['Hello {name}', 'hash1'], [fbt._param('name', 'World')], {
+          hk: 'hash1',
+        })
+        .toString(),
+    ).toBe('Hallo World');
+  });
+
+  it('should not affect the global locale', () => {
+    createFixedFbt('de_DE');
+    expect(Hooks.getViewerContext().locale).toBe('en_US');
+  });
+
+  it('should work with fbs for plain string results', () => {
+    const { fbs } = createFixedFbt('de_DE');
+    expect(
+      fbs._(['Simple text', 'hash2'], null, { hk: 'hash2' }).toString(),
+    ).toBe('Einfacher Text');
+  });
+
+  it('should fall back to source string when no translation exists', () => {
+    const { fbt } = createFixedFbt('ja_JP');
+    expect(fbt._('Untranslated text').toString()).toBe('Untranslated text');
+  });
+
+  it('should support fixing the gender', () => {
+    const { fbt } = createFixedFbt('de_DE', 'female');
+    expect(Hooks.getViewerContext().locale).toBe('en_US');
+    // The fixed fbt has its own gender context
+    expect(fbt).toBeDefined();
+  });
+
+  it('should allow concurrent usage of different locales', () => {
+    const de = createFixedFbt('de_DE');
+    const fr = createFixedFbt('fr_FR');
+
+    expect(
+      de.fbt
+        ._(['Hello {name}', 'hash1'], [de.fbt._param('name', 'World')], {
+          hk: 'hash1',
+        })
+        .toString(),
+    ).toBe('Hallo World');
+
+    expect(
+      fr.fbt
+        ._(['Hello {name}', 'hash1'], [fr.fbt._param('name', 'World')], {
+          hk: 'hash1',
+        })
+        .toString(),
+    ).toBe('Bonjour World');
+
+    // Global locale is still unchanged
+    expect(Hooks.getViewerContext().locale).toBe('en_US');
+  });
+
+  it('should use translations registered after creation', () => {
+    const { fbt } = createFixedFbt('es_ES');
+
+    // No translations yet
+    expect(
+      fbt._(['Hello', 'hash_es'], null, { hk: 'hash_es' }).toString(),
+    ).toBe('Hello');
+
+    // Register translations after creation
+    FbtTranslations.mergeTranslations({
+      es_ES: { hash_es: 'Hola' },
+    });
+
+    expect(
+      fbt._(['Hello', 'hash_es'], null, { hk: 'hash_es' }).toString(),
+    ).toBe('Hola');
+  });
+});

--- a/packages/fbtee/src/createFixedFbt.tsx
+++ b/packages/fbtee/src/createFixedFbt.tsx
@@ -1,0 +1,50 @@
+import { fbsParam, fbsPlural } from './fbs.tsx';
+import { createRuntime, fbtParam, fbtPlural } from './fbt.tsx';
+import FbtTranslations from './FbtTranslations.tsx';
+import Hooks, { FbtRuntimeCallInput, FbtTranslatedInput } from './Hooks.tsx';
+import IntlVariations from './IntlVariations.tsx';
+import { Gender, resolveGender } from './setupLocaleContext.tsx';
+
+export default function createFixedFbt(locale: string, gender?: Gender) {
+  const resolvedGender = gender
+    ? resolveGender(gender)
+    : IntlVariations.GENDER_UNKNOWN;
+
+  const getViewerContext = () => ({
+    GENDER: resolvedGender,
+    locale,
+  });
+
+  const getTranslatedInput = ({
+    args,
+    options,
+    table,
+  }: FbtRuntimeCallInput): FbtTranslatedInput => {
+    const hashKey = options?.hk;
+    const translations = FbtTranslations.getRegisteredTranslations()[locale];
+
+    return hashKey == null || translations?.[hashKey] == null
+      ? { args, table }
+      : { args, table: translations[hashKey] };
+  };
+
+  const fbt = createRuntime({
+    getErrorListener: Hooks.getErrorListener,
+    getResult: Hooks.getFbtResult,
+    getTranslatedInput,
+    getViewerContext,
+    param: fbtParam,
+    plural: fbtPlural,
+  });
+
+  const fbs = createRuntime({
+    getErrorListener: Hooks.getErrorListener,
+    getResult: Hooks.getFbsResult,
+    getTranslatedInput,
+    getViewerContext,
+    param: fbsParam,
+    plural: fbsPlural,
+  });
+
+  return { fbs, fbt };
+}

--- a/packages/fbtee/src/fbs.tsx
+++ b/packages/fbtee/src/fbs.tsx
@@ -1,38 +1,46 @@
 import invariant from 'invariant';
-import fbt, { createRuntime, Variations } from './fbt.tsx';
+import { createRuntime, fbtParam, fbtPlural, Variations } from './fbt.tsx';
 import FbtPureStringResult from './FbtPureStringResult.tsx';
 import Hooks from './Hooks.tsx';
 
+export function fbsParam(
+  label: string,
+  value?: string | FbtPureStringResult,
+  variations?: Variations,
+) {
+  if (value instanceof FbtPureStringResult) {
+    value = String(value);
+  }
+  invariant(
+    typeof value === 'string',
+    'Expected fbs parameter value to be the result of fbs(), <fbs/>, or a string; ' +
+      'instead we got `%s` (type: %s)',
+    value,
+    typeof value,
+  );
+  return fbtParam(label, value, variations);
+}
+
+export function fbsPlural(
+  count: number,
+  label?: string | null,
+  value?: string | FbtPureStringResult,
+) {
+  if (value instanceof FbtPureStringResult) {
+    value = String(value);
+  }
+  invariant(
+    value == null || typeof value === 'string',
+    'Expected fbs plural UI value to be nullish or the result of fbs(), <fbs/>, or a string; ' +
+      'instead we got `%s` (type: %s)',
+    value,
+    typeof value,
+  );
+  return fbtPlural(count, label, value);
+}
+
 export default createRuntime({
   getResult: Hooks.getFbsResult,
-  param: (
-    label,
-    value?: string | FbtPureStringResult,
-    variations?: Variations,
-  ) => {
-    if (value instanceof FbtPureStringResult) {
-      value = String(value);
-    }
-    invariant(
-      typeof value === 'string',
-      'Expected fbs parameter value to be the result of fbs(), <fbs/>, or a string; ' +
-        'instead we got `%s` (type: %s)',
-      value,
-      typeof value,
-    );
-    return fbt._param(label, value, variations);
-  },
-  plural: (count, label, value?: string | FbtPureStringResult) => {
-    if (value instanceof FbtPureStringResult) {
-      value = String(value);
-    }
-    invariant(
-      value == null || typeof value === 'string',
-      'Expected fbs plural UI value to be nullish or the result of fbs(), <fbs/>, or a string; ' +
-        'instead we got `%s` (type: %s)',
-      value,
-      typeof value,
-    );
-    return fbt._plural(count, label, value);
-  },
+  param: fbsParam,
+  plural: fbsPlural,
 });

--- a/packages/fbtee/src/fbs.tsx
+++ b/packages/fbtee/src/fbs.tsx
@@ -43,4 +43,5 @@ export default createRuntime({
   getResult: Hooks.getFbsResult,
   param: fbsParam,
   plural: fbsPlural,
+  runtimeKey: 'fbs',
 });

--- a/packages/fbtee/src/fbt.tsx
+++ b/packages/fbtee/src/fbt.tsx
@@ -18,6 +18,7 @@ import Hooks, {
   FbtRuntimeInput,
   FbtTableArgs,
   FbtTranslatedInput,
+  getLocaleOverrideHook,
   ResolverFn,
 } from './Hooks.tsx';
 import intlNumUtils from './intlNumUtils.tsx';
@@ -86,6 +87,23 @@ export type Variations =
   | [variation: ParamVariationType['number'], value?: number | null]
   | [variation: ParamVariationType['gender'], value: GenderConst];
 
+export type FbtLocaleOverride = {
+  fbs: {
+    _: (
+      input: FbtRuntimeInput,
+      args?: FbtTableArgs | null,
+      opts?: FbtInputOpts | null,
+    ) => unknown;
+  };
+  fbt: {
+    _: (
+      input: FbtRuntimeInput,
+      args?: FbtTableArgs | null,
+      opts?: FbtInputOpts | null,
+    ) => unknown;
+  };
+} | null;
+
 export function createRuntime<P, T extends BaseResult | string>({
   getErrorListener = Hooks.getErrorListener,
   getResult,
@@ -93,6 +111,7 @@ export function createRuntime<P, T extends BaseResult | string>({
   getViewerContext = Hooks.getViewerContext,
   param,
   plural,
+  runtimeKey = 'fbt',
 }: {
   getErrorListener?: (context: FbtErrorContext) => IFbtErrorListener | null;
   getResult: ResolverFn<T>;
@@ -100,6 +119,7 @@ export function createRuntime<P, T extends BaseResult | string>({
   getViewerContext?: () => typeof IntlViewerContext;
   param: (label: string, value: P, variations?: Variations) => FbtTableArg;
   plural: (count: number, label?: string | null, value?: P) => FbtTableArg;
+  runtimeKey?: 'fbs' | 'fbt';
 }) {
   const cachedResults = new Map<PatternString, T>();
   return Object.assign(
@@ -113,7 +133,15 @@ export function createRuntime<P, T extends BaseResult | string>({
         inputTable: FbtRuntimeInput,
         inputArgs?: FbtTableArgs | null,
         options?: FbtInputOpts | null,
+        localeOverride?: FbtLocaleOverride,
       ): T => {
+        if (localeOverride) {
+          return localeOverride[runtimeKey]._(
+            inputTable,
+            inputArgs,
+            options,
+          ) as T;
+        }
         let { args, table } = getTranslatedInput({
           args: inputArgs || null,
           options: options || null,
@@ -175,6 +203,9 @@ export function createRuntime<P, T extends BaseResult | string>({
           return result;
         }
       },
+
+      __locale: (): FbtLocaleOverride =>
+        (getLocaleOverrideHook()?.() as FbtLocaleOverride) ?? null,
       _enum: (
         value: FbtTableKey,
         range: {
@@ -283,4 +314,5 @@ export default createRuntime<string | number, FbtResult>({
   getResult: Hooks.getFbtResult,
   param: fbtParam,
   plural: fbtPlural,
+  runtimeKey: 'fbt',
 });

--- a/packages/fbtee/src/fbt.tsx
+++ b/packages/fbtee/src/fbt.tsx
@@ -14,8 +14,10 @@ import GenderConst from './GenderConst.tsx';
 import getAllSubstitutions from './getAllSubstitutions.tsx';
 import Hooks, {
   FbtInputOpts,
+  FbtRuntimeCallInput,
   FbtRuntimeInput,
   FbtTableArgs,
+  FbtTranslatedInput,
   ResolverFn,
 } from './Hooks.tsx';
 import intlNumUtils from './intlNumUtils.tsx';
@@ -29,8 +31,11 @@ import type {
   BaseResult,
   FbtConjunction,
   FbtDelimiter,
+  FbtErrorContext,
+  IFbtErrorListener,
   NestedFbtContentItems,
 } from './Types.ts';
+import type IntlViewerContext from './ViewerContext.tsx';
 
 const ParamVariation: ParamVariationType = {
   gender: 1,
@@ -82,11 +87,17 @@ export type Variations =
   | [variation: ParamVariationType['gender'], value: GenderConst];
 
 export function createRuntime<P, T extends BaseResult | string>({
+  getErrorListener = Hooks.getErrorListener,
   getResult,
+  getTranslatedInput = Hooks.getTranslatedInput,
+  getViewerContext = Hooks.getViewerContext,
   param,
   plural,
 }: {
+  getErrorListener?: (context: FbtErrorContext) => IFbtErrorListener | null;
   getResult: ResolverFn<T>;
+  getTranslatedInput?: (input: FbtRuntimeCallInput) => FbtTranslatedInput;
+  getViewerContext?: () => typeof IntlViewerContext;
   param: (label: string, value: P, variations?: Variations) => FbtTableArg;
   plural: (count: number, label?: string | null, value?: P) => FbtTableArg;
 }) {
@@ -103,7 +114,7 @@ export function createRuntime<P, T extends BaseResult | string>({
         inputArgs?: FbtTableArgs | null,
         options?: FbtInputOpts | null,
       ): T => {
-        let { args, table } = Hooks.getTranslatedInput({
+        let { args, table } = getTranslatedInput({
           args: inputArgs || null,
           options: options || null,
           table: inputTable,
@@ -117,7 +128,7 @@ export function createRuntime<P, T extends BaseResult | string>({
           }
           args.unshift(
             FbtTableAccessor.getGenderResult(
-              getGenderVariations(Hooks.getViewerContext().GENDER),
+              getGenderVariations(getViewerContext().GENDER),
               null,
             ),
           );
@@ -153,7 +164,7 @@ export function createRuntime<P, T extends BaseResult | string>({
               ? [fbtContent]
               : (fbtContent as NestedFbtContentItems),
             options?.hk,
-            Hooks.getErrorListener({
+            getErrorListener({
               hash: options?.hk,
               translation: patternString,
             }),
@@ -219,46 +230,57 @@ export function createRuntime<P, T extends BaseResult | string>({
   );
 }
 
+export const fbtParam = (
+  label: string,
+  value: number | string,
+  variations?: Variations,
+) => {
+  const substitution = { [label]: value };
+  if (variations) {
+    if (variations[0] === ParamVariation.number) {
+      const number = variations.length > 1 ? variations[1] : value;
+      invariant(typeof number === 'number', 'fbt.param expected number');
+
+      const variation = getNumberVariations(number); // this will throw if `number` is invalid
+      if (typeof value === 'number') {
+        substitution[label] =
+          intlNumUtils.formatNumberWithThousandDelimiters(value);
+      }
+      return FbtTableAccessor.getNumberResult(variation, substitution);
+    } else if (variations[0] === ParamVariation.gender) {
+      const gender = variations[1];
+      invariant(gender != null, 'expected gender value');
+      return FbtTableAccessor.getGenderResult(
+        getGenderVariations(gender),
+        substitution,
+      );
+    } else {
+      invariant(false, 'Unknown invariant mask');
+    }
+  } else {
+    return FbtTableAccessor.getSubstitution(substitution);
+  }
+};
+
+export const fbtPlural = (
+  count: number,
+  label?: string | null,
+  value?: number | string,
+) =>
+  FbtTableAccessor.getNumberResult(
+    getNumberVariations(count),
+    label
+      ? {
+          [label]:
+            typeof value === 'number'
+              ? intlNumUtils.formatNumberWithThousandDelimiters(value)
+              : value || intlNumUtils.formatNumberWithThousandDelimiters(count),
+        }
+      : null,
+  );
+
 export default createRuntime<string | number, FbtResult>({
   getResult: Hooks.getFbtResult,
-  param: (label: string, value: number | string, variations?: Variations) => {
-    const substitution = { [label]: value };
-    if (variations) {
-      if (variations[0] === ParamVariation.number) {
-        const number = variations.length > 1 ? variations[1] : value;
-        invariant(typeof number === 'number', 'fbt.param expected number');
-
-        const variation = getNumberVariations(number); // this will throw if `number` is invalid
-        if (typeof value === 'number') {
-          substitution[label] =
-            intlNumUtils.formatNumberWithThousandDelimiters(value);
-        }
-        return FbtTableAccessor.getNumberResult(variation, substitution);
-      } else if (variations[0] === ParamVariation.gender) {
-        const gender = variations[1];
-        invariant(gender != null, 'expected gender value');
-        return FbtTableAccessor.getGenderResult(
-          getGenderVariations(gender),
-          substitution,
-        );
-      } else {
-        invariant(false, 'Unknown invariant mask');
-      }
-    } else {
-      return FbtTableAccessor.getSubstitution(substitution);
-    }
-  },
-  plural: (count: number, label?: string | null, value?: number | string) =>
-    FbtTableAccessor.getNumberResult(
-      getNumberVariations(count),
-      label
-        ? {
-            [label]:
-              typeof value === 'number'
-                ? intlNumUtils.formatNumberWithThousandDelimiters(value)
-                : value ||
-                  intlNumUtils.formatNumberWithThousandDelimiters(count),
-          }
-        : null,
-    ),
+  param: fbtParam,
+  plural: fbtPlural,
 });

--- a/packages/fbtee/src/index-server.tsx
+++ b/packages/fbtee/src/index-server.tsx
@@ -2,6 +2,7 @@ import fbsInternal from './fbs.tsx';
 import fbtInternal from './fbt.tsx';
 import type { FbsAPI, FbtAPI } from './Types.ts';
 
+export { default as createFixedFbt } from './createFixedFbt.tsx';
 export { default as IntlVariations } from './IntlVariations.tsx';
 export { default as setupFbtee } from './setupFbtee.tsx';
 export { default as GenderConst } from './GenderConst.tsx';

--- a/packages/fbtee/src/index-server.tsx
+++ b/packages/fbtee/src/index-server.tsx
@@ -3,6 +3,7 @@ import fbtInternal from './fbt.tsx';
 import type { FbsAPI, FbtAPI } from './Types.ts';
 
 export { default as createFixedFbt } from './createFixedFbt.tsx';
+export { default as FixedLocaleContext } from './FixedLocaleContext.tsx';
 export { default as IntlVariations } from './IntlVariations.tsx';
 export { default as setupFbtee } from './setupFbtee.tsx';
 export { default as GenderConst } from './GenderConst.tsx';

--- a/packages/fbtee/src/setupLocaleContext.tsx
+++ b/packages/fbtee/src/setupLocaleContext.tsx
@@ -123,6 +123,7 @@ export default function setupLocaleContext({
         GENDER: gender,
         locale: getLocale(),
       }),
+      loadLocale,
     },
     translations,
   });


### PR DESCRIPTION
**Disclaimer:** This was written entirely by Opus 4.6 High. I believe I guided it thoroughly into the right direction. I reviewed and tested the result myself.

## Summary

Adds locale-fixed translation support for fbtee — the equivalent of i18next's [`getFixedT`](https://www.i18next.com/overview/api#getfixedt). Two complementary APIs:

### 1. `<FixedLocaleContext>` — React (transparent)

A context provider that transparently overrides the locale for all `<fbt>`, `fbt()`, `<fbs>`, and `fbs()` calls in **descendant components**. No call-site changes needed in children.

```tsx
import { fbt, FixedLocaleContext } from "fbtee";

function App() {
  return (
    <div>
      <h1><fbt desc="title">Hello World</fbt></h1>
      <Suspense fallback="Loading...">
        <FixedLocaleContext locale="de_DE">
          <GermanPreview />
        </FixedLocaleContext>
      </Suspense>
    </div>
  );
}

function GermanPreview() {
  return <p><fbt desc="greeting">Hello World</fbt></p>;
}
```

**On-demand translation loading:** If translations for the requested locale are not yet loaded and a `loadLocale` hook has been registered (via `setupLocaleContext`), `FixedLocaleContext` will suspend until translations are fetched. Wrap in `<Suspense>` to handle the loading state. Already-loaded locales render immediately.

> **Note:** Like all React context providers, the override only affects child components, not `fbt`/`fbs` calls in the same component that renders `<FixedLocaleContext>`.

### 2. `createFixedFbt(locale, gender?)` — Non-React (programmatic)

Returns `{ fbt, fbs }` runtimes bound to a specific locale. Shadow the global `fbt`/`fbs` binding and the babel plugin compiles calls normally:

```tsx
import { createFixedFbt } from "fbtee";
const { fbt } = createFixedFbt("de_DE");

const greeting = fbt("Hello", "greeting"); // → "Hallo"
```

## How it works

### Babel plugin

The plugin detects React components (`/^[A-Z]/`), hooks (`/^use[A-Z0-9]/`), and `React.forwardRef`/`React.memo` callbacks that contain `fbt._()` or `fbs._()` calls. For these functions, it:

1. Injects `const __fbtLocaleOverride = fbt.__locale?.() ?? null;` at the top
2. Passes `__fbtLocaleOverride` as 4th argument to all `fbt._()` / `fbs._()` calls

Non-component functions are left unchanged (use global locale).

### Runtime

- `fbt.__locale()` reads from `FbtLocaleOverrideContext` via a registered hook
- `fbt._()` checks the 4th argument: if present, delegates to the fixed runtime; otherwise uses global hooks as before
- `<FixedLocaleContext>` provides the fixed runtime (created by `createFixedFbt`) via React context
- On-demand loading: if translations are missing, uses the registered `loadLocale` hook + React `use()` to suspend until loaded, then merges into `FbtTranslations`
- `createFixedFbt` creates isolated runtimes with their own `getTranslatedInput` and `getViewerContext`

### Backward compatibility

| Scenario | Behavior |
|----------|----------|
| Old plugin + new runtime | `fbt._()` with 3 args → 4th is `undefined` → global hooks |
| New plugin + old runtime | `fbt._()` with 4 args → extra arg ignored by JS |
| No `<FixedLocaleContext>` in tree | `__locale?.()` returns `null` → global hooks |
| `FixedLocaleContext` not imported | Hook never registered → `null` |

## Changes

### `packages/babel-plugin-fbtee/`
- **`src/index.tsx`** — `injectLocaleOverrides()` in `Program.exit`: component/hook detection + hook injection + 4th arg addition

### `packages/fbtee/`
- **`src/fbt.tsx`** — `FbtLocaleOverride` type, `__locale()` method, `localeOverride` 4th param on `_()`, `runtimeKey` param on `createRuntime`
- **`src/fbs.tsx`** — `runtimeKey: "fbs"`
- **`src/Hooks.tsx`** — `LoadLocaleFn` type, `loadLocale` in `Hooks`, `getLoadLocale()`, `getLocaleOverrideHook()` / `setLocaleOverrideHook()`
- **`src/setupLocaleContext.tsx`** — Registers `loadLocale` in hooks during setup
- **`src/FixedLocaleContext.tsx`** — New: React context provider with on-demand translation loading via `useEnsureLocaleLoaded` + Suspense
- **`src/createFixedFbt.tsx`** — New: isolated runtime factory
- **`src/index-server.tsx`** — Exports `createFixedFbt` and `FixedLocaleContext`

### `example/`
- **`fixedLocale.html`** + **`src/fixedLocale.tsx`** + **`src/example/FixedLocaleDemo.tsx`** — Comprehensive demo page with on-demand loading (1s simulated delay), Suspense fallbacks, all test cases
- **`src/example/Example.tsx`** — Multi-Locale Preview section

### Tests
- 13 babel plugin tests (component detection, hook detection, non-component exclusion, fbs, forwardRef/memo, 4th arg)
- 6 runtime `FixedLocaleContext` tests (fixed locale, isolation, nesting, global unaffected, fbs, async loading with Suspense)
- 7 runtime `createFixedFbt` tests (locale, fbs, fallback, gender, concurrency, late registration)