### PR TITLE
[babel-plugin-fbtee] export processJSON method

### DIFF
--- a/packages/babel-plugin-fbtee/src/index.tsx
+++ b/packages/babel-plugin-fbtee/src/index.tsx
@@ -29,7 +29,14 @@ export { default as replaceClearTokensWithTokenAliases } from './replaceClearTok
 export { mapLeaves } from './JSFbtUtil.tsx';
 export { ModuleName, BindingNames } from './FbtConstants.tsx';
 export type { FbtTableKey, PatternHash, PatternString };
-export type { TranslationGroup } from './bin/translateUtils.tsx';
+export { processJSON } from './bin/translateUtils.tsx';
+export type {
+  LocaleToHashToTranslationResult,
+  Options as TranslateOptions,
+  TranslatedGroups,
+  TranslationGroup,
+  Translations,
+} from './bin/translateUtils.tsx';
 
 const isRequireCall = (node: CallExpression) =>
   node.type === 'CallExpression' &&


### PR DESCRIPTION
Export `processJSON`, pure in memory JS method (e.g. no external binaries involved) used by `fbtee translate` CLI command.
`fbtee translate` under the hood uses `processJSON` to produce "final" localized JSON file.

My use case it: I'm building a panel for translations management and I would like to have a possibility to build "final JSON" (output that is normally produced by `fbtee translate` CLI command) in there and then serve it directly via API (since its JSON) to the app for example to achieve instant translations preview

@cpojer pinging u since this one seems quite simple and it would help me 😁 